### PR TITLE
ci(perf): only run conventional commit on 'master' branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pr_conventional_commit:
     name: PR Conventional Commit
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Thanks to your contribute, while please finish below tasks:

# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] Use `<leader>gl` to copy git link.
- [ ] Use `<leader>gL` to open git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
