### PR TITLE
fix(path): resolve symlink in Windows

### DIFF
--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -215,7 +215,7 @@ local function make_link_data(range)
         vim.inspect(file_in_rev_result)
     )
 
-    local buf_path_on_cwd = util.path_relative()
+    local buf_path_on_cwd = util.path_relative() --[[@as string]]
     logger.debug(
         "|make_link_data| buf_path_on_cwd:%s",
         vim.inspect(buf_path_on_cwd)

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -197,7 +197,7 @@ local function make_link_data(range)
         vim.inspect(rev)
     )
 
-    local buf_path_on_root = util.path_relative(root)
+    local buf_path_on_root = util.path_relative(root) --[[@as string]]
     logger.debug(
         "|make_link_data| root(%s):%s, buf_path_on_root(%s):%s",
         vim.inspect(type(root)),

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -197,7 +197,7 @@ local function make_link_data(range)
         vim.inspect(rev)
     )
 
-    local buf_path_on_root = util.relative_path(root)
+    local buf_path_on_root = util.path_relative(root)
     logger.debug(
         "|make_link_data| root(%s):%s, buf_path_on_root(%s):%s",
         vim.inspect(type(root)),
@@ -215,7 +215,7 @@ local function make_link_data(range)
         vim.inspect(file_in_rev_result)
     )
 
-    local buf_path_on_cwd = util.relative_path()
+    local buf_path_on_cwd = util.path_relative()
     logger.debug(
         "|make_link_data| buf_path_on_cwd:%s",
         vim.inspect(buf_path_on_cwd)

--- a/lua/gitlinker/logger.lua
+++ b/lua/gitlinker/logger.lua
@@ -72,15 +72,15 @@ local function log(level, msg)
     local msg_lines = vim.split(msg, "\n", { plain = true })
     if Configs.console_log and level >= LogLevels.INFO then
         local msg_chunks = {}
-        local prefix = ""
-        if level == LogLevels.ERROR then
-            prefix = "error! "
-        elseif level == LogLevels.WARN then
-            prefix = "warning! "
-        end
+        -- local prefix = ""
+        -- if level == LogLevels.ERROR then
+        --     prefix = "error! "
+        -- elseif level == LogLevels.WARN then
+        --     prefix = "warning! "
+        -- end
         for _, line in ipairs(msg_lines) do
             table.insert(msg_chunks, {
-                string.format("[gitlinker] %s%s", prefix, line),
+                string.format("[gitlinker] %s", --[[prefix,]] line),
                 LogHighlights[level],
             })
         end

--- a/lua/gitlinker/spawn.lua
+++ b/lua/gitlinker/spawn.lua
@@ -228,6 +228,7 @@ end
 function Spawn:run()
     self.process_handle, self.process_id = vim.loop.spawn(self.cmds[1], {
         args = vim.list_slice(self.cmds, 2),
+        cwd = self.cwd,
         stdio = { nil, self.out_pipe, self.err_pipe },
         hide = true,
         -- verbatim = true,

--- a/lua/gitlinker/spawn.lua
+++ b/lua/gitlinker/spawn.lua
@@ -60,6 +60,7 @@ end
 --- @alias SpawnLineConsumer fun(line:string):any
 --- @class Spawn
 --- @field cmds string[]
+--- @field cwd string?
 --- @field fn_out_line_consumer SpawnLineConsumer
 --- @field fn_err_line_consumer SpawnLineConsumer
 --- @field out_pipe uv_pipe_t
@@ -81,10 +82,9 @@ local function dummy_stderr_line_consumer(line)
 end
 
 --- @param cmds string[]
---- @param fn_out_line_consumer SpawnLineConsumer
---- @param fn_err_line_consumer SpawnLineConsumer?
+--- @param opts {on_stdout:SpawnLineConsumer,on_stderr:SpawnLineConsumer?,cwd:string?}
 --- @return Spawn?
-function Spawn:make(cmds, fn_out_line_consumer, fn_err_line_consumer)
+function Spawn:make(cmds, opts)
     local out_pipe = vim.loop.new_pipe(false) --[[@as uv_pipe_t]]
     local err_pipe = vim.loop.new_pipe(false) --[[@as uv_pipe_t]]
     if not out_pipe or not err_pipe then
@@ -93,9 +93,9 @@ function Spawn:make(cmds, fn_out_line_consumer, fn_err_line_consumer)
 
     local o = {
         cmds = cmds,
-        fn_out_line_consumer = fn_out_line_consumer,
-        fn_err_line_consumer = fn_err_line_consumer
-            or dummy_stderr_line_consumer,
+        cwd = opts.cwd or vim.fn.getcwd(),
+        fn_out_line_consumer = opts.on_stdout,
+        fn_err_line_consumer = opts.on_stderr or dummy_stderr_line_consumer,
         out_pipe = out_pipe,
         err_pipe = err_pipe,
         out_buffer = nil,

--- a/lua/gitlinker/util.lua
+++ b/lua/gitlinker/util.lua
@@ -22,10 +22,11 @@ local function path_relative(cwd)
     cwd = path_normalize(cwd)
 
     local bufpath = vim.api.nvim_buf_get_name(0)
+    bufpath = vim.fn.resolve(bufpath)
     bufpath = path_normalize(bufpath)
 
     logger.debug(
-        "|util.path_relative| enter, cwd:%s, buf_path:%s",
+        "|util.path_relative| enter, cwd:%s, bufpath:%s",
         vim.inspect(cwd),
         vim.inspect(bufpath)
     )

--- a/test/spawn_spec.lua
+++ b/test/spawn_spec.lua
@@ -48,7 +48,10 @@ describe("spawn", function()
     end)
     describe("[Spawn]", function()
         it("open", function()
-            local sp = spawn.Spawn:make({ "cat", "README.md" }, function() end) --[[@as Spawn]]
+            local sp = spawn.Spawn:make(
+                { "cat", "README.md" },
+                { on_stdout = function() end }
+            ) --[[@as Spawn]]
             assert_eq(type(sp), "table")
             assert_eq(type(sp.cmds), "table")
             assert_eq(#sp.cmds, 2)
@@ -69,7 +72,10 @@ describe("spawn", function()
                 assert_eq(line, lines[i])
                 i = i + 1
             end
-            local sp = spawn.Spawn:make({ "cat", "README.md" }, process_line) --[[@as Spawn]]
+            local sp = spawn.Spawn:make(
+                { "cat", "README.md" },
+                { on_stdout = process_line }
+            ) --[[@as Spawn]]
             local pos = sp:_consume_line(content, process_line)
             if pos <= #content then
                 local line = content:sub(pos, #content)
@@ -87,7 +93,10 @@ describe("spawn", function()
                 assert_eq(line, lines[i])
                 i = i + 1
             end
-            local sp = spawn.Spawn:make({ "cat", "README.md" }, process_line) --[[@as Spawn]]
+            local sp = spawn.Spawn:make(
+                { "cat", "README.md" },
+                { on_stdout = process_line }
+            ) --[[@as Spawn]]
             local content_splits =
                 vim.split(content, "\n", { plain = true, trimempty = false })
             for j, splits in ipairs(content_splits) do
@@ -110,7 +119,10 @@ describe("spawn", function()
                 assert_eq(line, lines[i])
                 i = i + 1
             end
-            local sp = spawn.Spawn:make({ "cat", "README.md" }, process_line) --[[@as Spawn]]
+            local sp = spawn.Spawn:make(
+                { "cat", "README.md" },
+                { on_stdout = process_line }
+            ) --[[@as Spawn]]
             local content_splits =
                 vim.split(content, " ", { plain = true, trimempty = false })
             for j, splits in ipairs(content_splits) do
@@ -136,8 +148,10 @@ describe("spawn", function()
                     assert_eq(line, lines[i])
                     i = i + 1
                 end
-                local sp =
-                    spawn.Spawn:make({ "cat", "README.md" }, process_line) --[[@as Spawn]]
+                local sp = spawn.Spawn:make(
+                    { "cat", "README.md" },
+                    { on_stdout = process_line }
+                ) --[[@as Spawn]]
                 local content_splits = vim.split(
                     content,
                     lower_char,
@@ -165,8 +179,10 @@ describe("spawn", function()
                     assert_eq(line, lines[i])
                     i = i + 1
                 end
-                local sp =
-                    spawn.Spawn:make({ "cat", "README.md" }, process_line) --[[@as Spawn]]
+                local sp = spawn.Spawn:make(
+                    { "cat", "README.md" },
+                    { on_stdout = process_line }
+                ) --[[@as Spawn]]
                 local content_splits = vim.split(
                     content,
                     upper_char,
@@ -183,7 +199,10 @@ describe("spawn", function()
             end)
         end
         it("stderr", function()
-            local sp = spawn.Spawn:make({ "cat", "README.md" }, function() end) --[[@as Spawn]]
+            local sp = spawn.Spawn:make(
+                { "cat", "README.md" },
+                { on_stdout = function() end }
+            ) --[[@as Spawn]]
             sp:_on_stderr(nil, nil)
             assert_true(sp.err_pipe:is_closing())
         end)
@@ -198,7 +217,10 @@ describe("spawn", function()
                 i = i + 1
             end
 
-            local sp = spawn.Spawn:make({ "cat", "README.md" }, process_line) --[[@as Spawn]]
+            local sp = spawn.Spawn:make(
+                { "cat", "README.md" },
+                { on_stdout = process_line }
+            ) --[[@as Spawn]]
             sp:run()
         end)
         it("iterate on lua/gitlinker.lua", function()
@@ -212,14 +234,16 @@ describe("spawn", function()
                 i = i + 1
             end
 
-            local sp =
-                spawn.Spawn:make({ "cat", "lua/gitlinker.lua" }, process_line) --[[@as Spawn]]
+            local sp = spawn.Spawn:make(
+                { "cat", "lua/gitlinker.lua" },
+                { on_stdout = process_line }
+            ) --[[@as Spawn]]
             sp:run()
         end)
         it("close handle", function()
             local sp = spawn.Spawn:make(
                 { "cat", "lua/gitlinker.lua" },
-                function() end
+                { on_stdout = function() end }
             ) --[[@as Spawn]]
             sp:run()
             assert_true(sp.process_handle ~= nil)


### PR DESCRIPTION
Thanks to your contribute, while please finish below tasks:

# Regression Test

## Platforms

- [x] windows
- [ ] macOS
- [x] linux

## Tasks

- [x] Use `<leader>gl` to copy git link.
- [x] Use `<leader>gL` to open git link in browser.
- [x] Copy git link in a symlink directory of git repo.
- [x] Copy git link in an un-pushed git branch, and receive an expected error.
- [x] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
