### PR TITLE
feat(markdown): add '?plain=1' for markdown files to link to code instead of preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Here's an example of git permalink: https://github.com/neovim/neovim/blob/2e156a
   - [Action](#action)
   - [API](#api)
   - [Key Mappings](#key-mappings)
-  - [Customization](#customization)
+- [Customization](#customization)
+  - [Vim Command](#vim-command)
+  - [Highlight](#highlight)
 - [Configuration](#configuration)
   - [Highlight Group](#highlight-group)
 - [Development](#development)
@@ -132,7 +134,7 @@ You could use below lua code to copy/open git link:
   }
   ```
 
-## Key Mappings
+### Key Mappings
 
 The above two operations are already defined with two default key mappings:
 
@@ -141,45 +143,49 @@ The above two operations are already defined with two default key mappings:
 
 ## Customization
 
-- To disable the default key mappings, set `mapping = false` in `setup()` function (see [Configuration](#configuration)).
+- To disable the default key mappings, set `mapping = false` in `setup()` function (also see [Configuration](#configuration)).
 
 - To create your own key mappings, please specify the `mapping` option in `setup()` function.
 
-- To create your own vim command, please use:
+### Vim Command
 
-  ```vim
-  " vimscript
-  command! -range GitLink lua require('gitlinker').link({ action = require('gitlinker.actions').system, lstart = vim.api.nvim_buf_get_mark(0, '<')[1], lend = vim.api.nvim_buf_get_mark(0, '>')[1] })
-  ```
+To create your own vim command, please use:
 
-  ```lua
-  -- lua
-  vim.api.nvim_create_user_command("GitLink", function()
-    require("gitlinker").link({
-      action = require("gitlinker.actions").system,
-      lstart = vim.api.nvim_buf_get_mark(0, '<')[1],
-      lend = vim.api.nvim_buf_get_mark(0, '>')[1]
-    })
-  end, {
-    range = true,
-  })
-  ```
+```vim
+" vimscript
+command! -range GitLink lua require('gitlinker').link({ action = require('gitlinker.actions').system, lstart = vim.api.nvim_buf_get_mark(0, '<')[1], lend = vim.api.nvim_buf_get_mark(0, '>')[1] })
+```
 
-  > Support command range is a little bit tricky, since you need to pass line range from command line to the `link` API.
+```lua
+-- lua
+vim.api.nvim_create_user_command("GitLink", function()
+require("gitlinker").link({
+  action = require("gitlinker.actions").system,
+  lstart = vim.api.nvim_buf_get_mark(0, '<')[1],
+  lend = vim.api.nvim_buf_get_mark(0, '>')[1]
+})
+end, {
+range = true,
+})
+```
 
-- To create your own highlight, please use:
+> Support command range is a little bit tricky, since you need to pass line range from command line to the `link` API.
 
-  ```lua
-  -- lua
-  vim.api.nvim_set_hl( 0, "NvimGitLinkerHighlightTextObject", { link = "Constant" })
-  ```
+### Highlight
 
-  ```vim
-  " vimscript
-  hi link NvimGitLinkerHighlightTextObject Constant
-  ```
+To create your own highlight, please use:
 
-  > Please see [Highlight Group](#highlight-group).
+```lua
+-- lua
+vim.api.nvim_set_hl( 0, "NvimGitLinkerHighlightTextObject", { link = "Constant" })
+```
+
+```vim
+" vimscript
+hi link NvimGitLinkerHighlightTextObject Constant
+```
+
+> Also see [Highlight Group](#highlight-group).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ require('gitlinker').setup({
   -- disable highlight by setting a value equal or less than 0
   highlight_duration = 500,
 
+  -- add '?plain=1' for '*.md' (markdown) files
+  add_plain_for_markdown = true,
+
   -- key mapping
   mapping = {
     ["<leader>gl"] = {

--- a/README.md
+++ b/README.md
@@ -209,42 +209,42 @@ require('gitlinker').setup({
   -- regex pattern based rules
   --- @type table<{[1]:string,[2]:string}>[]
   pattern_rules = {
-    -- 'git@github' end with '.git' suffix
+    -- 'git@github' with '.git' suffix
     {
       "^git@github%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)%.git$",
       "https://github.%1/%2/%3/blob/",
     },
-    -- 'git@github' end without '.git' suffix
+    -- 'git@github' without '.git' suffix
     {
       "^git@github%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)$",
       "https://github.%1/%2/%3/blob/",
     },
-    -- 'http(s)?://github' end with '.git' suffix
+    -- 'http(s)?://github' with '.git' suffix
     {
       "^https?://github%.([_%.%-%w]+)/([%.%-%w]+)/([_%.%-%w]+)%.git$",
       "https://github.%1/%2/%3/blob/",
     },
-    -- 'http(s)?://github' end without '.git' suffix
+    -- 'http(s)?://github' without '.git' suffix
     {
       "^https?://github%.([_%.%-%w]+)/([%.%-%w]+)/([_%.%-%w]+)$",
       "https://github.%1/%2/%3/blob/",
     },
-    -- 'git@gitlab' end with '.git' suffix
+    -- 'git@gitlab' with '.git' suffix
     {
       "^git@gitlab%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)%.git$",
       "https://gitlab.%1/%2/%3/blob/",
     },
-    -- 'git@gitlab' end without '.git' suffix
+    -- 'git@gitlab' without '.git' suffix
     {
       "^git@gitlab%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)$",
       "https://gitlab.%1/%2/%3/blob/",
     },
-    -- 'http(s)?://gitlab' end with '.git' suffix
+    -- 'http(s)?://gitlab' with '.git' suffix
     {
       "^https?://gitlab%.([_%.%-%w]+)/([%.%-%w]+)/([_%.%-%w]+)%.git$",
       "https://gitlab.%1/%2/%3/blob/",
     },
-    -- 'http(s)?://gitlab' end without '.git' suffix
+    -- 'http(s)?://gitlab' without '.git' suffix
     {
       "^https?://gitlab%.([_%.%-%w]+)/([%.%-%w]+)/([_%.%-%w]+)$",
       "https://gitlab.%1/%2/%3/blob/",

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -15,6 +15,11 @@ local Defaults = {
     --- @type integer
     highlight_duration = 500,
 
+    -- add '?plain=1' for '*.md' (markdown) files
+    --
+    --- @type boolean
+    add_plain_for_markdown = true,
+
     -- key mappings
     --
     --- @alias KeyMappingConfig {action:fun(url:string):nil,desc:string?}
@@ -34,47 +39,42 @@ local Defaults = {
     --
     --- @type table<{[1]:string,[2]:string}>[]
     pattern_rules = {
-        -- 'git@github' end with '.git' suffix, add '?plain=1' for '*.md' files.
+        -- 'git@github' with '.git' suffix
         {
             "^git@github%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)%.git$",
             "https://github.%1/%2/%3/blob/",
         },
-        -- 'git@github' end with '.git' suffix
-        {
-            "^git@github%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)%.git$",
-            "https://github.%1/%2/%3/blob/",
-        },
-        -- 'git@github' end without '.git' suffix
+        -- 'git@github' without '.git' suffix
         {
             "^git@github%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)$",
             "https://github.%1/%2/%3/blob/",
         },
-        -- 'http(s)?://github' end with '.git' suffix
+        -- 'http(s)?://github' with '.git' suffix
         {
             "^https?://github%.([_%.%-%w]+)/([%.%-%w]+)/([_%.%-%w]+)%.git$",
             "https://github.%1/%2/%3/blob/",
         },
-        -- 'http(s)?://github' end without '.git' suffix
+        -- 'http(s)?://github' without '.git' suffix
         {
             "^https?://github%.([_%.%-%w]+)/([%.%-%w]+)/([_%.%-%w]+)$",
             "https://github.%1/%2/%3/blob/",
         },
-        -- 'git@gitlab' end with '.git' suffix
+        -- 'git@gitlab' with '.git' suffix
         {
             "^git@gitlab%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)%.git$",
             "https://gitlab.%1/%2/%3/blob/",
         },
-        -- 'git@gitlab' end without '.git' suffix
+        -- 'git@gitlab' without '.git' suffix
         {
             "^git@gitlab%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)$",
             "https://gitlab.%1/%2/%3/blob/",
         },
-        -- 'http(s)?://gitlab' end with '.git' suffix
+        -- 'http(s)?://gitlab' with '.git' suffix
         {
             "^https?://gitlab%.([_%.%-%w]+)/([%.%-%w]+)/([_%.%-%w]+)%.git$",
             "https://gitlab.%1/%2/%3/blob/",
         },
-        -- 'http(s)?://gitlab' end without '.git' suffix
+        -- 'http(s)?://gitlab' without '.git' suffix
         {
             "^https?://gitlab%.([_%.%-%w]+)/([%.%-%w]+)/([_%.%-%w]+)$",
             "https://gitlab.%1/%2/%3/blob/",
@@ -307,7 +307,7 @@ local function _make_sharable_permalinks(host_url, lk)
         return url
     end
     url = string.format([[%s#L%d]], url, lk.lstart)
-    if lk.lend and lk.lend ~= lk.lstart then
+    if lk.lend and lk.lend > lk.lstart then
         url = string.format([[%s-L%d]], url, lk.lend)
     end
     return url

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -304,21 +304,30 @@ end
 --- @return string
 local function _make_sharable_permalinks(host_url, lk, opts)
     local url = string.format([[%s%s/%s]], host_url, lk.rev, lk.file)
-    if not lk.lstart then
-        return url
-    end
 
-    if
-        type(opts) == "table"
+    local add_plain = type(opts) == "table"
         and type(opts.add_plain_for_markdown) == "boolean"
         and opts.add_plain_for_markdown
-    then
+    local endswith_md = type(url) == "string"
+        and string.len(url) >= 3
+        and url:sub(#url - 2, #url):lower() == ".md"
+    -- logger.debug(
+    --     "|_make_sharable_permalinks| url:%s, add plain:%s, url sub:%s, lower:%s, endswith '*.md':%s",
+    --     vim.inspect(url),
+    --     vim.inspect(add_plain),
+    --     vim.inspect(url:sub(#url - 2, #url)),
+    --     vim.inspect(url:sub(#url - 2, #url):lower()),
+    --     vim.inspect(url:sub(#url - 2, #url):lower() == ".md")
+    -- )
+    if add_plain and endswith_md then
         url = url .. [[?plain=1]]
     end
 
-    url = string.format([[%s#L%d]], url, lk.lstart)
-    if lk.lend and lk.lend > lk.lstart then
-        url = string.format([[%s-L%d]], url, lk.lend)
+    if type(lk.lstart) == "number" then
+        url = string.format([[%s#L%d]], url, lk.lstart)
+        if type(lk.lend) == "number" and lk.lend > lk.lstart then
+            url = string.format([[%s-L%d]], url, lk.lend)
+        end
     end
 
     return url
@@ -347,7 +356,7 @@ local function link(opts)
         lk.remote_url
     )
 
-    local url = _make_sharable_permalinks(host_url, lk)
+    local url = _make_sharable_permalinks(host_url, lk, opts)
     if opts.action then
         opts.action(url)
     end

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -300,16 +300,27 @@ end
 
 --- @param host_url string
 --- @param lk Linker
+--- @param opts Options?
 --- @return string
-local function _make_sharable_permalinks(host_url, lk)
+local function _make_sharable_permalinks(host_url, lk, opts)
     local url = string.format([[%s%s/%s]], host_url, lk.rev, lk.file)
     if not lk.lstart then
         return url
     end
+
+    if
+        type(opts) == "table"
+        and type(opts.add_plain_for_markdown) == "boolean"
+        and opts.add_plain_for_markdown
+    then
+        url = url .. [[?plain=1]]
+    end
+
     url = string.format([[%s#L%d]], url, lk.lstart)
     if lk.lend and lk.lend > lk.lstart then
         url = string.format([[%s-L%d]], url, lk.lend)
     end
+
     return url
 end
 

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -34,6 +34,11 @@ local Defaults = {
     --
     --- @type table<{[1]:string,[2]:string}>[]
     pattern_rules = {
+        -- 'git@github' end with '.git' suffix, add '?plain=1' for '*.md' files.
+        {
+            "^git@github%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)%.git$",
+            "https://github.%1/%2/%3/blob/",
+        },
         -- 'git@github' end with '.git' suffix
         {
             "^git@github%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)%.git$",

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -82,7 +82,7 @@ local Defaults = {
     },
 
     -- function based rules: function(remote_url) => host_url
-    -- this will override the default pattern_rules.
+    -- this function has higher priority and could override the default pattern_rules.
     --
     -- here's an example:
     --
@@ -243,7 +243,10 @@ end
 local function _map_remote_to_host(remote_url)
     local custom_rules = Configs.custom_rules
     if type(custom_rules) == "function" then
-        return custom_rules(remote_url)
+        local result = custom_rules(remote_url)
+        if result then
+            return result
+        end
     end
 
     local pattern_rules = Configs.pattern_rules


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] Use `<leader>gl` to copy git link.
- [x] Use `<leader>gL` to open git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
