### PR TITLE
docs(rules): the 'custom_rules' has higher priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,9 @@ require('gitlinker').setup({
     },
   },
 
-  -- function based rules: function(remote_url) => host_url.
-  -- this function will override the `pattern_rules`.
+  -- higher priority rules to override the default pattern_rules.
+  -- function(remote_url) => host_url
+  --
   -- here's an example:
   --
   -- ```lua

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -81,8 +81,8 @@ local Defaults = {
         },
     },
 
-    -- function based rules: function(remote_url) => host_url
-    -- this function has higher priority and could override the default pattern_rules.
+    -- higher priority rules to override the default pattern_rules.
+    -- function(remote_url) => host_url
     --
     -- here's an example:
     --
@@ -340,7 +340,7 @@ end
 --- @return string?
 local function link(opts)
     opts = vim.tbl_deep_extend("force", vim.deepcopy(Configs), opts or {})
-    -- logger.debug("[link] merged opts: %s", vim.inspect(opts))
+    logger.debug("[link] merged opts: %s", vim.inspect(opts))
 
     local range = (
         type(opts.lstart) == "number" and type(opts.lend) == "number"


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] Use `<leader>gl` to copy git link.
- [x] Use `<leader>gL` to open git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
