### PR TITLE
feat(rules): add 'override_rules' to override default 'pattern_rules'

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ require('gitlinker').setup({
   -- but 'override_rules' will only prepend your own rules before 'pattern_rules', e.g. override.
   override_rules = nil,
 
-  -- higher priority rules to override the default pattern_rules.
+  -- function based rules to override the default pattern_rules.
   -- function(remote_url) => host_url
   --
   -- here's an example:

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ require('gitlinker').setup({
   -- **note**:
   --
   -- if you directly add your own rules in 'pattern_rules', it will remove other rules.
-  -- but 'override_rules' will only prepend your own rules before 'pattern_rules'.
+  -- but 'override_rules' will only prepend your own rules before 'pattern_rules', e.g. override.
   override_rules = nil,
 
   -- higher priority rules to override the default pattern_rules.

--- a/README.md
+++ b/README.md
@@ -215,8 +215,7 @@ require('gitlinker').setup({
     },
   },
 
-  -- regex pattern based rules
-  --- @type table<{[1]:string,[2]:string}>[]
+  -- regex pattern based rules, mapping url from 'host' to 'remote'.
   pattern_rules = {
     -- 'git@github' with '.git' suffix
     {
@@ -259,6 +258,14 @@ require('gitlinker').setup({
       "https://gitlab.%1/%2/%3/blob/",
     },
   },
+
+  -- override 'pattern_rules' with your own rules here.
+  --
+  -- **note**:
+  --
+  -- if you directly add your own rules in 'pattern_rules', it will remove other rules.
+  -- but 'override_rules' will only prepend your own rules before 'pattern_rules'.
+  override_rules = nil,
 
   -- higher priority rules to override the default pattern_rules.
   -- function(remote_url) => host_url
@@ -305,6 +312,55 @@ require('gitlinker').setup({
   file_log = false,
 })
 ````
+
+To add more git hosts, or map to your own hosts, please use:
+
+```lua
+require('gitlinker').setup({
+  override_rules = {
+    {
+      "^git@your-personal-host%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)%.git$",
+      "https://github.%1/%2/%3/blob/",
+    },
+    {
+      "^git@your-personal-hots%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)$",
+      "https://github-personal.%1/%2/%3/blob/",
+    },
+  }
+})
+```
+
+The above example will map `git@your-personal-host` to `https://github`, override original mapping from `git@github` to `https://github`.
+
+To fully customize git hosts, please use:
+
+```lua
+require('gitlinker').setup({
+  custom_rules = function(remote_url)
+    local rules = {
+      {
+        "^git@github%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)%.git$",
+        "https://github.%1/%2/%3/blob/",
+      },
+      {
+        "^git@github%.([_%.%-%w]+):([%.%-%w]+)/([_%.%-%w]+)$",
+        "https://github.%1/%2/%3/blob/",
+      },
+    }
+    for _, rule in ipairs(rules) do
+      local pattern = rule[1]
+      local replace = rule[2]
+      if string.match(remote_url, pattern) then
+        local result = string.gsub(remote_url, pattern, replace)
+        return result
+      end
+    end
+    return nil
+  end,
+})
+```
+
+The above example will technically allow you map anything (which is also the implementation of 'pattern_rules').
 
 ### Highlight Group
 

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -81,6 +81,9 @@ local Defaults = {
         },
     },
 
+    -- override 'pattern_rules' with your own rules here.
+    override_rules = nil,
+
     -- higher priority rules to override the default pattern_rules.
     -- function(remote_url) => host_url
     --
@@ -275,6 +278,10 @@ local function _map_remote_to_host(remote_url)
     end
 
     logger.debug("|_map_remote_to_host| use new pattern rules schema")
+    pattern_rules = vim.list_extend(
+        vim.deepcopy(Configs.override_rules or {}),
+        vim.deepcopy(pattern_rules)
+    )
     for i, rule in ipairs(pattern_rules) do
         local pattern = rule[1]
         local replace = rule[2]

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -89,7 +89,7 @@ local Defaults = {
     -- but 'override_rules' will only prepend your own rules before 'pattern_rules', e.g. override.
     override_rules = nil,
 
-    -- higher priority rules to override the default pattern_rules.
+    -- function based rules to override the default pattern_rules.
     -- function(remote_url) => host_url
     --
     -- here's an example:

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -86,7 +86,7 @@ local Defaults = {
     -- **note**:
     --
     -- if you directly add your own rules in 'pattern_rules', it will remove other rules.
-    -- but 'override_rules' will only prepend your own rules before 'pattern_rules'.
+    -- but 'override_rules' will only prepend your own rules before 'pattern_rules', e.g. override.
     override_rules = nil,
 
     -- higher priority rules to override the default pattern_rules.

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -82,6 +82,11 @@ local Defaults = {
     },
 
     -- override 'pattern_rules' with your own rules here.
+    --
+    -- **note**:
+    --
+    -- if you directly add your own rules in 'pattern_rules', it will remove other rules.
+    -- but 'override_rules' will only prepend your own rules before 'pattern_rules'.
     override_rules = nil,
 
     -- higher priority rules to override the default pattern_rules.


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] Use `<leader>gl` to copy git link.
- [x] Use `<leader>gL` to open git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
