### PR TITLE
perf(routers): add placeholder to avoid loop call

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <a href="https://app.codecov.io/github/linrongbin16/gitlinker.nvim"><img alt="codecov" src="https://img.shields.io/codecov/c/github/linrongbin16/gitlinker.nvim?logo=codecov&logoColor=F01F7A&label=Codecov" /></a>
 </p>
 
-> Maintained fork of [ruifm's gitlinker](https://github.com/ruifm/gitlinker.nvim), refactored with bug fixes, git alias host, `/blame` url support and other improvements.
+> Maintained fork of [ruifm's gitlinker](https://github.com/ruifm/gitlinker.nvim), refactored with bug fixes, ssh host alias, `/blame` url support and other improvements.
 
 A lua plugin for [Neovim](https://github.com/neovim/neovim) to generate sharable file permalinks (with line ranges) for git host websites. Inspired by [tpope/vim-fugitive](https://github.com/tpope/vim-fugitive)'s `:GBrowse`.
 
@@ -53,7 +53,7 @@ PRs are welcomed for other git host websites!
    - Customize/disable default key mappings.
 2. New Features:
    - Windows support.
-   - Respect ssh config alias host.
+   - Respect ssh host alias.
    - Add `?plain=1` for markdown files.
    - Support `/blame` (by default is `/blob`).
 3. Improvements:
@@ -67,7 +67,7 @@ Requirement:
 
 - neovim &ge; v0.7.
 - [git](https://git-scm.com/).
-- [ssh](https://www.openssh.com/) (optional for resolve git alias host).
+- [ssh](https://www.openssh.com/) (optional for resolve ssh host alias).
 
 ### [packer.nvim](https://github.com/wbthomason/packer.nvim)
 

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -7,18 +7,17 @@ local deprecation = require("gitlinker.deprecation")
 --- @type gitlinker.Options
 local Defaults = {
   -- print permanent url in command line
-  --
-  --- @type boolean
   message = true,
 
   -- highlight the linked region
-  --
-  --- @type integer
   highlight_duration = 500,
 
+  -- highlight group
+  highlight_group = {
+    NvimGitLinkerHighlightTextObject = { link = "Search" },
+  },
+
   -- key mappings
-  --
-  --- @type table<string, {action:gitlinker.Action,desc:string?}>
   mapping = {
     ["<leader>gl"] = {
       action = require("gitlinker.actions").clipboard,
@@ -31,8 +30,6 @@ local Defaults = {
   },
 
   -- router bindings
-  --
-  --- @type table<"browse"|"blame", table<string, gitlinker.Router>>
   router_binding = {
     browse = {
       ["^github%.com"] = require("gitlinker.routers").github_browse,
@@ -47,18 +44,12 @@ local Defaults = {
   },
 
   -- enable debug
-  --
-  --- @type boolean
   debug = false,
 
   -- write logs to console(command line)
-  --
-  --- @type boolean
   console_log = true,
 
   -- write logs to file
-  --
-  --- @type boolean
   file_log = false,
 }
 
@@ -148,9 +139,13 @@ local function setup(opts)
 
   -- Configure highlight group
   if Configs.highlight_duration > 0 then
-    local hl_name = "NvimGitLinkerHighlightTextObject"
-    if not highlight.hl_group_exists(hl_name) then
-      vim.api.nvim_set_hl(0, hl_name, { link = "Search" })
+    local hl_group = "NvimGitLinkerHighlightTextObject"
+    if not highlight.hl_group_exists(hl_group) then
+      vim.api.nvim_set_hl(
+        0,
+        hl_group,
+        Configs.highlight_group.NvimGitLinkerHighlightTextObject
+      )
     end
   end
 

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -179,7 +179,7 @@ local function link(opts)
     return nil
   end
 
-  local ok, url = pcall(router, lk)
+  local ok, url = pcall(router, lk, true)
   logger.ensure(
     ok and type(url) == "string" and string.len(url) > 0,
     "fatal: failed to generate permanent url from remote url (%s): %s",

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -12,11 +12,6 @@ local Defaults = {
   -- highlight the linked region
   highlight_duration = 500,
 
-  -- highlight group
-  highlight_group = {
-    NvimGitLinkerHighlightTextObject = { link = "Search" },
-  },
-
   -- key mappings
   mapping = {
     ["<leader>gl"] = {
@@ -141,11 +136,7 @@ local function setup(opts)
   if Configs.highlight_duration > 0 then
     local hl_group = "NvimGitLinkerHighlightTextObject"
     if not highlight.hl_group_exists(hl_group) then
-      vim.api.nvim_set_hl(
-        0,
-        hl_group,
-        Configs.highlight_group.NvimGitLinkerHighlightTextObject
-      )
+      vim.api.nvim_set_hl(0, hl_group, { link = "Search" })
     end
   end
 

--- a/lua/gitlinker/routers.lua
+++ b/lua/gitlinker/routers.lua
@@ -115,12 +115,17 @@ local BROWSE_BINDING = {}
 
 --- @alias gitlinker.Router fun(lk:gitlinker.Linker):string?
 --- @param lk gitlinker.Linker
+--- @param _placeholder boolean
 --- @return string?
-local function browse(lk)
+local function browse(lk, _placeholder)
   -- logger.debug(
   --   "|routers.browse| BROWSE_BINDING:%s",
   --   vim.inspect(BROWSE_BINDING)
   -- )
+  assert(
+    type(_placeholder) == "boolean" and _placeholder,
+    string.format("the second param %s must be true", vim.inspect(_placeholder))
+  )
   for pattern, route in pairs(BROWSE_BINDING) do
     if string.match(lk.host, pattern) then
       logger.debug(
@@ -163,9 +168,14 @@ end
 local BLAME_BINDING = {}
 
 --- @param lk gitlinker.Linker
+--- @param _placeholder boolean
 --- @return string?
-local function blame(lk)
-  logger.debug("|routers.blame| BLAME_BINDING:%s", vim.inspect(BLAME_BINDING))
+local function blame(lk, _placeholder)
+  -- logger.debug("|routers.blame| BLAME_BINDING:%s", vim.inspect(BLAME_BINDING))
+  assert(
+    type(_placeholder) == "boolean" and _placeholder,
+    string.format("the second param %s must be true", vim.inspect(_placeholder))
+  )
   for pattern, route in pairs(BLAME_BINDING) do
     if string.match(lk.host, pattern) then
       return route(lk)

--- a/lua/gitlinker/routers.lua
+++ b/lua/gitlinker/routers.lua
@@ -139,10 +139,12 @@ local function browse(lk, _placeholder)
       return route(lk)
     end
   end
-  logger.ensure(
+  assert(
     false,
-    "%s not support, please bind it in 'router_binding'!",
-    vim.inspect(lk.host)
+    string.format(
+      "%s not support, please bind it in 'router_binding'!",
+      vim.inspect(lk.host)
+    )
   )
   return nil
 end
@@ -187,10 +189,12 @@ local function blame(lk, _placeholder)
       return route(lk)
     end
   end
-  logger.ensure(
+  assert(
     false,
-    "%s not support, please bind it in 'router_binding'!",
-    vim.inspect(lk.host)
+    string.format(
+      "%s not support, please bind it in 'router_binding'!",
+      vim.inspect(lk.host)
+    )
   )
   return nil
 end
@@ -202,23 +206,11 @@ local function setup(router_binding)
     vim.deepcopy(BROWSE_BINDING),
     router_binding.browse or {}
   )
-  for _, route in pairs(BROWSE_BINDING) do
-    logger.ensure(
-      route ~= browse,
-      "must not use 'browse' itself in 'router_binding.browse'! please use other implementations e.g. github_browse, bitbucket_browse, etc."
-    )
-  end
   BLAME_BINDING = vim.tbl_extend(
     "force",
     vim.deepcopy(BLAME_BINDING),
     router_binding.blame or {}
   )
-  for _, route in pairs(BLAME_BINDING) do
-    logger.ensure(
-      route ~= blame,
-      "must not use 'blame' itself in 'router_binding.blame'! please use other implementations e.g. github_blame, bitbucket_blame, etc."
-    )
-  end
 end
 
 local M = {

--- a/lua/gitlinker/routers.lua
+++ b/lua/gitlinker/routers.lua
@@ -124,7 +124,10 @@ local function browse(lk, _placeholder)
   -- )
   assert(
     type(_placeholder) == "boolean" and _placeholder,
-    string.format("the second param %s must be true", vim.inspect(_placeholder))
+    string.format(
+      "%s must be true, make sure you didn't set this function in 'router_binding'",
+      vim.inspect(_placeholder)
+    )
   )
   for pattern, route in pairs(BROWSE_BINDING) do
     if string.match(lk.host, pattern) then
@@ -174,7 +177,10 @@ local function blame(lk, _placeholder)
   -- logger.debug("|routers.blame| BLAME_BINDING:%s", vim.inspect(BLAME_BINDING))
   assert(
     type(_placeholder) == "boolean" and _placeholder,
-    string.format("the second param %s must be true", vim.inspect(_placeholder))
+    string.format(
+      "%s must be true, make sure you didn't set this function in 'router_binding'",
+      vim.inspect(_placeholder)
+    )
   )
   for pattern, route in pairs(BLAME_BINDING) do
     if string.match(lk.host, pattern) then

--- a/test/routers_spec.lua
+++ b/test/routers_spec.lua
@@ -28,7 +28,7 @@ describe("routers", function()
         rev = "399b1d05473c711fc5592a6ffc724e231c403486",
         file = "lua/gitlinker/logger.lua",
         file_changed = false,
-      } --[[@as gitlinker.Linker]])
+      } --[[@as gitlinker.Linker]], true)
       assert_eq(
         actual,
         "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua"
@@ -46,7 +46,7 @@ describe("routers", function()
         lstart = 1,
         lend = 1,
         file_changed = false,
-      }--[[@as gitlinker.Linker]])
+      }--[[@as gitlinker.Linker]], true)
       assert_eq(
         actual,
         "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1"
@@ -64,7 +64,7 @@ describe("routers", function()
         lstart = 1,
         lend = 1,
         file_changed = false,
-      }--[[@as gitlinker.Linker]])
+      }--[[@as gitlinker.Linker]], true)
       assert_eq(
         actual,
         "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1"
@@ -82,7 +82,7 @@ describe("routers", function()
         lstart = 2,
         lend = 5,
         file_changed = false,
-      }--[[@as gitlinker.Linker]])
+      }--[[@as gitlinker.Linker]], true)
       assert_eq(
         actual,
         "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L2-L5"
@@ -134,7 +134,7 @@ describe("routers", function()
         rev = "399b1d05473c711fc5592a6ffc724e231c403486",
         file = "lua/gitlinker/logger.lua",
         file_changed = false,
-      } --[[@as gitlinker.Linker]])
+      } --[[@as gitlinker.Linker]], true)
       assert_eq(
         actual,
         "https://github.com/linrongbin16/gitlinker.nvim/blame/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua"
@@ -152,7 +152,7 @@ describe("routers", function()
         lstart = 1,
         lend = 2,
         file_changed = false,
-      }--[[@as gitlinker.Linker]])
+      }--[[@as gitlinker.Linker]], true)
       assert_eq(
         actual,
         "https://github.com/linrongbin16/gitlinker.nvim/blame/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1-L2"


### PR DESCRIPTION
# Regression Test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] Use `<leader>gl` to copy git link.
- [x] Use `<leader>gL` to open git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
