### PR TITLE
break(mapping)!: drop of default key mappings!

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,21 +170,6 @@ require('gitlinker').setup({
     desc = "Generate git permanent link",
   },
 
-  --- @deprecated please use to 'GitLink'
-  -- key mapping
-  mapping = {
-    -- copy git link to clipboard
-    ["<leader>gl"] = {
-      action = require("gitlinker.actions").clipboard,
-      desc = "Copy git link to clipboard",
-    },
-    -- open git link in browser
-    ["<leader>gL"] = {
-      action = require("gitlinker.actions").system,
-      desc = "Open git link in browser",
-    },
-  },
-
   -- router
   router = {
     browse = {
@@ -276,9 +261,9 @@ end
 --- @param lk gitlinker.Linker
 local function your_router(lk)
   local builder = ""
-  -- protocol: 'git', 'http', 'https'
+  -- protocol: 'git@', 'ssh://git@', 'http://', 'https://'
   builder = builder
-    .. (lk.protocol == "git" and "https://" or (lk.protocol .. "://"))
+    .. (string_endswith(lk.protocol, "git@") and "https://" or lk.protocol)
   -- host: 'github.com', 'gitlab.com', 'bitbucket.org'
   builder = builder .. lk.host .. "/"
   -- user: 'linrongbin16', 'neovim'

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ PRs are welcomed for other git host websites!
 
 ## Break Changes & Updates
 
-1. Bug fix:
-   - Customize/disable default key mappings.
+1. Break Changes:
+   - Drop off default key mappings.
 2. New Features:
+   - Provide `GitLink` command.
    - Windows support.
    - Respect ssh host alias.
    - Add `?plain=1` for markdown files.
    - Support `/blame` (by default is `/blob`).
-   - Provide `GitLink` command and drop off default key mappings.
 3. Improvements:
    - Use stderr from git command as error message.
    - Performant child process IO via `uv.spawn`.

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -23,19 +23,6 @@ local Defaults = {
     desc = "Generate git permanent link",
   },
 
-  --- @deprecated please use to 'GitLink'
-  -- key mappings
-  mapping = {
-    ["<leader>gl"] = {
-      action = require("gitlinker.actions").clipboard,
-      desc = "Copy git link to clipboard",
-    },
-    ["<leader>gL"] = {
-      action = require("gitlinker.actions").system,
-      desc = "Open git link in browser",
-    },
-  },
-
   -- router bindings
   router = {
     browse = {
@@ -240,34 +227,10 @@ local function setup(opts)
     desc = Configs.command.desc,
   })
 
-  -- key mappings
-  local key_mappings = nil
-  if type(opts) == "table" and opts["mapping"] ~= nil then
-    if type(opts["mapping"]) == "table" then
-      key_mappings = opts["mapping"]
-    end
-  else
-    ---@diagnostic disable-next-line: deprecated
-    key_mappings = Defaults.mapping
-  end
-
-  if type(key_mappings) == "table" then
-    for k, v in pairs(key_mappings) do
-      local opt = {
-        noremap = true,
-        silent = true,
-      }
-      if v.desc then
-        opt.desc = v.desc
-      end
-      vim.keymap.set({ "n", "v" }, k, function()
-        deprecation.notify(
-          "'mapping' option is deprecated! please set 'mapping=false' and migrate to 'GitLink' command."
-        )
-        logger.debug("|setup| keymap v:%s", vim.inspect(v))
-        link({ action = v.action, router = v.router })
-      end, opt)
-    end
+  if type(Configs.mapping) == "table" then
+    deprecation.notify(
+      "'mapping' option is deprecated! please migrate to 'GitLink' command."
+    )
   end
 
   -- Configure highlight group


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] Use `GitLink` to copy git link.
- [x] Use `GitLink!` to open git link in browser.
- [x] Use `GitLink blame` to copy the `/blame` git link.
- [x] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
