### PR TITLE
refactor(api): hide 'browse'/'blame' api

### DIFF
--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -68,6 +68,7 @@ local function deprecated_notification(opts)
   end
 end
 
+--- @alias gitlinker.Router fun(lk:gitlinker.Linker):string
 --- @param lk gitlinker.Linker
 --- @return string?
 local function _browse(lk)

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -2,7 +2,6 @@ local logger = require("gitlinker.logger")
 local linker = require("gitlinker.linker")
 local highlight = require("gitlinker.highlight")
 local deprecation = require("gitlinker.deprecation")
-local utils = require("gitlinker.utils")
 
 --- @alias gitlinker.Options table<any, any>
 --- @type gitlinker.Options
@@ -69,7 +68,53 @@ local function deprecated_notification(opts)
   end
 end
 
---- @param opts {action:gitlinker.Action,router:gitlinker.Router?}
+--- @param lk gitlinker.Linker
+--- @return string?
+local function _browse(lk)
+  for pattern, route in pairs(Configs.router.browse) do
+    if string.match(lk.host, pattern) then
+      logger.debug(
+        "|browse| match router:%s with pattern:%s",
+        vim.inspect(route),
+        vim.inspect(pattern)
+      )
+      return route(lk)
+    end
+  end
+  assert(
+    false,
+    string.format(
+      "%s not support, please bind it in 'router'!",
+      vim.inspect(lk.host)
+    )
+  )
+  return nil
+end
+
+--- @param lk gitlinker.Linker
+--- @return string?
+local function _blame(lk)
+  for pattern, route in pairs(Configs.router.blame) do
+    if string.match(lk.host, pattern) then
+      logger.debug(
+        "|blame| match router:%s with pattern:%s",
+        vim.inspect(route),
+        vim.inspect(pattern)
+      )
+      return route(lk)
+    end
+  end
+  assert(
+    false,
+    string.format(
+      "%s not support, please bind it in 'router'!",
+      vim.inspect(lk.host)
+    )
+  )
+  return nil
+end
+
+--- @param opts {action:gitlinker.Action,router:gitlinker.Router}
 --- @return string?
 local function link(opts)
   -- logger.debug("[link] merged opts: %s", vim.inspect(opts))
@@ -79,17 +124,12 @@ local function link(opts)
     return nil
   end
 
-  local router = opts.router or require("gitlinker.routers").browse
-  if not router then
-    return nil
-  end
-
-  local ok, url = pcall(router, lk, true)
+  local ok, url = pcall(opts.router, lk, true)
   logger.debug(
     "|link| ok:%s, url:%s, router:%s",
     vim.inspect(ok),
     vim.inspect(url),
-    vim.inspect(router)
+    vim.inspect(opts.router)
   )
   logger.ensure(
     ok and type(url) == "string" and string.len(url) > 0,
@@ -211,9 +251,9 @@ local function setup(opts)
       vim.inspect(command_opts),
       vim.inspect(parsed_args)
     )
-    local router = require("gitlinker.routers").browse
+    local router = _browse
     if parsed_args == "blame" then
-      router = require("gitlinker.routers").blame
+      router = _blame
     end
     local action = require("gitlinker.actions").clipboard
     if command_opts.bang then
@@ -249,6 +289,8 @@ end
 local M = {
   setup = setup,
   link = link,
+  _browse = _browse,
+  _blame = _blame,
 }
 
 return M

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -235,9 +235,6 @@ local function setup(opts)
     file_log = Configs.file_log,
   })
 
-  -- router binding
-  require("gitlinker.routers").setup(Configs.router or {})
-
   -- command
   vim.api.nvim_create_user_command(Configs.command.name, function(command_opts)
     local parsed_args = (

--- a/lua/gitlinker/routers.lua
+++ b/lua/gitlinker/routers.lua
@@ -111,44 +111,6 @@ local function bitbucket_browse(lk)
   return builder:build("src")
 end
 
-local BROWSE_BINDING = {}
-
---- @alias gitlinker.Router fun(lk:gitlinker.Linker):string
---- @param lk gitlinker.Linker
---- @param _placeholder boolean
---- @return string?
-local function browse(lk, _placeholder)
-  logger.debug(
-    "|routers.browse| BROWSE_BINDING:%s",
-    vim.inspect(BROWSE_BINDING)
-  )
-  assert(
-    type(_placeholder) == "boolean" and _placeholder,
-    string.format(
-      "%s must be true, make sure you didn't set this function in 'router'",
-      vim.inspect(_placeholder)
-    )
-  )
-  for pattern, route in pairs(BROWSE_BINDING) do
-    if string.match(lk.host, pattern) then
-      logger.debug(
-        "|routers.browse| match router:%s with pattern:%s",
-        vim.inspect(route),
-        vim.inspect(pattern)
-      )
-      return route(lk)
-    end
-  end
-  assert(
-    false,
-    string.format(
-      "%s not support, please bind it in 'router'!",
-      vim.inspect(lk.host)
-    )
-  )
-  return nil
-end
-
 --- @param lk gitlinker.Linker
 --- @return string
 local function github_blame(lk)
@@ -170,51 +132,7 @@ local function bitbucket_blame(lk)
   return builder:build("annotate")
 end
 
-local BLAME_BINDING = {}
-
---- @param lk gitlinker.Linker
---- @param _placeholder boolean
---- @return string?
-local function blame(lk, _placeholder)
-  logger.debug("|routers.blame| BLAME_BINDING:%s", vim.inspect(BLAME_BINDING))
-  assert(
-    type(_placeholder) == "boolean" and _placeholder,
-    string.format(
-      "%s must be true, make sure you didn't set this function in 'router'",
-      vim.inspect(_placeholder)
-    )
-  )
-  for pattern, route in pairs(BLAME_BINDING) do
-    if string.match(lk.host, pattern) then
-      logger.debug(
-        "|routers.blame| match router:%s with pattern:%s",
-        vim.inspect(route),
-        vim.inspect(pattern)
-      )
-      return route(lk)
-    end
-  end
-  assert(
-    false,
-    string.format(
-      "%s not support, please bind it in 'router'!",
-      vim.inspect(lk.host)
-    )
-  )
-  return nil
-end
-
---- @param bindings gitlinker.Options
-local function setup(bindings)
-  BROWSE_BINDING =
-    vim.tbl_extend("force", vim.deepcopy(BROWSE_BINDING), bindings.browse or {})
-  BLAME_BINDING =
-    vim.tbl_extend("force", vim.deepcopy(BLAME_BINDING), bindings.blame or {})
-end
-
 local M = {
-  setup = setup,
-
   -- Builder
   Builder = Builder,
 
@@ -226,13 +144,11 @@ local M = {
   github_browse = github_browse,
   gitlab_browse = gitlab_browse,
   bitbucket_browse = bitbucket_browse,
-  browse = browse,
 
   -- blame: /blame, /annotate
   github_blame = github_blame,
   gitlab_blame = gitlab_blame,
   bitbucket_blame = bitbucket_blame,
-  blame = blame,
 }
 
 return M

--- a/lua/gitlinker/routers.lua
+++ b/lua/gitlinker/routers.lua
@@ -140,12 +140,12 @@ local M = {
   LC_range = LC_range,
   lines_range = lines_range,
 
-  -- browse: /blob, /src
+  -- browse: `/blob`, `/src`
   github_browse = github_browse,
   gitlab_browse = gitlab_browse,
   bitbucket_browse = bitbucket_browse,
 
-  -- blame: /blame, /annotate
+  -- blame: `/blame`, `/annotate`
   github_blame = github_blame,
   gitlab_blame = gitlab_blame,
   bitbucket_blame = bitbucket_blame,

--- a/test/gitlinker_spec.lua
+++ b/test/gitlinker_spec.lua
@@ -5,35 +5,16 @@ describe("gitlinker", function()
   local assert_true = assert.is_true
   local assert_false = assert.is_false
 
+  local gitlinker = require("gitlinker")
+
   before_each(function()
     vim.api.nvim_command("cd " .. cwd)
     vim.opt.swapfile = false
-    local logger = require("gitlinker.logger")
-    logger.setup()
+    gitlinker.setup()
     vim.cmd([[ edit lua/gitlinker.lua ]])
   end)
 
-  local gitlinker = require("gitlinker")
   local utils = require("gitlinker.utils")
-  describe("[link]", function()
-    it("link", function()
-      gitlinker.setup()
-      local actual = gitlinker.link({
-        action = require("gitlinker.actions").clipboard,
-        router = require("gitlinker.routers").blob,
-      })
-      print(string.format("link:%s\n", vim.inspect(actual)))
-      if actual then
-        assert_eq(type(actual), "string")
-        assert_true(
-          utils.string_startswith(
-            actual,
-            "https://github.com/linrongbin16/gitlinker.nvim/blob"
-          )
-        )
-      end
-    end)
-  end)
   describe("_browse/_blame", function()
     it("without line numbers", function()
       local actual = gitlinker._browse({

--- a/test/gitlinker_spec.lua
+++ b/test/gitlinker_spec.lua
@@ -34,4 +34,110 @@ describe("gitlinker", function()
       end
     end)
   end)
+  describe("_browse/_blame", function()
+    it("without line numbers", function()
+      local actual = gitlinker._browse({
+        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
+        protocol = "git@",
+        host = "github.com",
+        user = "linrongbin16",
+        repo = "gitlinker.nvim.git",
+        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
+        file = "lua/gitlinker/logger.lua",
+        file_changed = false,
+      } --[[@as gitlinker.Linker]], true)
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua"
+      )
+    end)
+    it("with line start", function()
+      local actual = gitlinker._browse({
+        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
+        protocol = "git@",
+        host = "github.com",
+        user = "linrongbin16",
+        repo = "gitlinker.nvim.git",
+        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
+        file = "lua/gitlinker/logger.lua",
+        lstart = 1,
+        lend = 1,
+        file_changed = false,
+      }--[[@as gitlinker.Linker]], true)
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1"
+      )
+    end)
+    it("with same line start and line end", function()
+      local actual = gitlinker._browse({
+        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
+        protocol = "git@",
+        host = "github.com",
+        user = "linrongbin16",
+        repo = "gitlinker.nvim.git",
+        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
+        file = "lua/gitlinker/logger.lua",
+        lstart = 1,
+        lend = 1,
+        file_changed = false,
+      }--[[@as gitlinker.Linker]], true)
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1"
+      )
+    end)
+    it("with different line start and line end", function()
+      local actual = gitlinker._browse({
+        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
+        protocol = "git@",
+        host = "github.com",
+        user = "linrongbin16",
+        repo = "gitlinker.nvim.git",
+        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
+        file = "lua/gitlinker/logger.lua",
+        lstart = 2,
+        lend = 5,
+        file_changed = false,
+      }--[[@as gitlinker.Linker]], true)
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L2-L5"
+      )
+    end)
+    it("without line numbers", function()
+      local actual = gitlinker._blame({
+        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
+        protocol = "git@",
+        host = "github.com",
+        user = "linrongbin16",
+        repo = "gitlinker.nvim.git",
+        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
+        file = "lua/gitlinker/logger.lua",
+        file_changed = false,
+      } --[[@as gitlinker.Linker]], true)
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/gitlinker.nvim/blame/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua"
+      )
+    end)
+    it("with line start", function()
+      local actual = gitlinker._blame({
+        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
+        protocol = "git@",
+        host = "github.com",
+        user = "linrongbin16",
+        repo = "gitlinker.nvim.git",
+        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
+        file = "lua/gitlinker/logger.lua",
+        lstart = 1,
+        lend = 2,
+        file_changed = false,
+      }--[[@as gitlinker.Linker]], true)
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/gitlinker.nvim/blame/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1-L2"
+      )
+    end)
+  end)
 end)

--- a/test/routers_spec.lua
+++ b/test/routers_spec.lua
@@ -18,76 +18,6 @@ describe("routers", function()
     file_log = true,
   })
   describe("[browse]", function()
-    it("without line numbers", function()
-      local actual = routers.browse({
-        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
-        protocol = "git@",
-        host = "github.com",
-        user = "linrongbin16",
-        repo = "gitlinker.nvim.git",
-        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
-        file = "lua/gitlinker/logger.lua",
-        file_changed = false,
-      } --[[@as gitlinker.Linker]], true)
-      assert_eq(
-        actual,
-        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua"
-      )
-    end)
-    it("with line start", function()
-      local actual = routers.browse({
-        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
-        protocol = "git@",
-        host = "github.com",
-        user = "linrongbin16",
-        repo = "gitlinker.nvim.git",
-        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
-        file = "lua/gitlinker/logger.lua",
-        lstart = 1,
-        lend = 1,
-        file_changed = false,
-      }--[[@as gitlinker.Linker]], true)
-      assert_eq(
-        actual,
-        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1"
-      )
-    end)
-    it("with same line start and line end", function()
-      local actual = routers.browse({
-        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
-        protocol = "git@",
-        host = "github.com",
-        user = "linrongbin16",
-        repo = "gitlinker.nvim.git",
-        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
-        file = "lua/gitlinker/logger.lua",
-        lstart = 1,
-        lend = 1,
-        file_changed = false,
-      }--[[@as gitlinker.Linker]], true)
-      assert_eq(
-        actual,
-        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1"
-      )
-    end)
-    it("with different line start and line end", function()
-      local actual = routers.browse({
-        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
-        protocol = "git@",
-        host = "github.com",
-        user = "linrongbin16",
-        repo = "gitlinker.nvim.git",
-        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
-        file = "lua/gitlinker/logger.lua",
-        lstart = 2,
-        lend = 5,
-        file_changed = false,
-      }--[[@as gitlinker.Linker]], true)
-      assert_eq(
-        actual,
-        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L2-L5"
-      )
-    end)
     it("bitbucket without line numbers", function()
       local actual = routers.bitbucket_browse({
         remote_url = "git@bitbucket.org:linrongbin16/gitlinker.nvim.git",
@@ -124,40 +54,6 @@ describe("routers", function()
     end)
   end)
   describe("[blame]", function()
-    it("without line numbers", function()
-      local actual = routers.blame({
-        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
-        protocol = "git@",
-        host = "github.com",
-        user = "linrongbin16",
-        repo = "gitlinker.nvim.git",
-        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
-        file = "lua/gitlinker/logger.lua",
-        file_changed = false,
-      } --[[@as gitlinker.Linker]], true)
-      assert_eq(
-        actual,
-        "https://github.com/linrongbin16/gitlinker.nvim/blame/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua"
-      )
-    end)
-    it("with line start", function()
-      local actual = routers.blame({
-        remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",
-        protocol = "git@",
-        host = "github.com",
-        user = "linrongbin16",
-        repo = "gitlinker.nvim.git",
-        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
-        file = "lua/gitlinker/logger.lua",
-        lstart = 1,
-        lend = 2,
-        file_changed = false,
-      }--[[@as gitlinker.Linker]], true)
-      assert_eq(
-        actual,
-        "https://github.com/linrongbin16/gitlinker.nvim/blame/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1-L2"
-      )
-    end)
     it("bitbucket without line numbers", function()
       local actual = routers.bitbucket_blame({
         remote_url = "git@github.com:linrongbin16/gitlinker.nvim.git",


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] Use `GitLink` to copy git link.
- [x] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
