### PR TITLE
docs(usage): wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,10 @@ You could use below command:
 - `GitLink blame`: generate the `/blame` url and copy to clipboard.
 - `GitLink! blame`: generate the `/blame` url and open in browser.
 
-There're two arguments working with `GitLink` for now: `browse` and `blame`, they're called routers. By default `GitLink` use `browse` router, that's why simply use `GitLink` could generate the `/blob` url, instead of typing `GitLink browse`.
+There're two **routers** provided:
 
-Note:
-
-- `browse` router could also generate for other git host websites, e.g., `/src` for bitbucket.org.
-- `blame` router could also generate for other git host websites, e.g., `/annotate` for bitbucket.org.
+- `browse`: generate the `/blob` urls (default router in `GitLink`), also work for other git host websites, e.g. generate `/src` for bitbucket.org.
+- `blame`: generate the `/blame` urls, also work for other git host websites, e.g. generate `/annotate` for bitbucket.org.
 
 <details>
 <summary><i>Click here to see recommended key mappings</i></summary>

--- a/README.md
+++ b/README.md
@@ -108,12 +108,15 @@ You could use below command:
 
 - `GitLink`: generate git link and copy to clipboard.
 - `GitLink!`: generate git link and open in browser.
-- `GitLink blame`: generate the `/blame` url and copy to clipboard, by default is `browse`.
+- `GitLink blame`: generate the `/blame` url and copy to clipboard.
+- `GitLink! blame`: generate the `/blame` url and open in browser.
 
-> Note:
->
-> - `browse` router could generate for other git host websites, e.g., `/src` for bitbucket.org.
-> - `blame` router could generate for other git host websites, e.g., `/annotate` for bitbucket.org.
+There're two arguments working with `GitLink` for now: `browse` and `blame`, they're called routers. By default `GitLink` use `browse` router, that's why simply use `GitLink` could generate the `/blob` url, instead of typing `GitLink browse`.
+
+Note:
+
+- `browse` router could also generate for other git host websites, e.g., `/src` for bitbucket.org.
+- `blame` router could also generate for other git host websites, e.g., `/annotate` for bitbucket.org.
 
 <details>
 <summary><i>Click here to see recommended key mappings</i></summary>


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
