### PR TITLE
feat(actions): Add wslview compatible feature

### DIFF
--- a/lua/gitlinker/actions.lua
+++ b/lua/gitlinker/actions.lua
@@ -15,6 +15,8 @@ local function system(url)
     job = vim.fn.jobstart({ "open", url })
   elseif vim.fn.has("win32") > 0 or vim.fn.has("win64") > 0 then
     job = vim.fn.jobstart({ "cmd", "/C", "start", url })
+  elseif vim.fn.executable("wslview") > 0 then
+    job = vim.fn.jobstart({ "wslview", url })
   else
     job = vim.fn.jobstart({ "xdg-open", url })
   end


### PR DESCRIPTION
I added  an option for using `wslview` command to open url, because wsl does not work with `xdg-open` without custom setting.



# Regression Test
This changed file has not been auto-tested, so I tested manually only for  `system` function on may local wsl environment. 
Detail:
1. Copy `system` function definition to clipboard.
1. Open neovim.
1. Paste my neovim command mode like `:lua <copied function body>`.
1. Call function like `:lua system("https://github.com")`.
1. I ensured opening the target page on Windows side browser.

And I did unittests via `vusted` and all green.

## Platforms

- [ ] windows
- [ ] macOS
- [x] linux  (using wsl)

## Tasks
If I was needed below them, I will do.
- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
