### PR TITLE
docs(config): optimize config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,9 @@ PRs are welcomed for other git host websites!
 ## Break Changes & Updates
 
 1. Break Changes:
-   - Drop off default key mappings.
+   - Drop off default key mappings, provide `GitLink` command.
 2. New Features:
-   - Provide `GitLink` command.
-   - Windows support.
+   - Windows (+wsl) support.
    - Respect ssh host alias.
    - Add `?plain=1` for markdown files.
    - Support `/blame` (by default is `/blob`).
@@ -106,10 +105,10 @@ require("lazy").setup({
 
 You could use below command:
 
-- `GitLink`: generate git link and copy to clipboard.
-- `GitLink!`: generate git link and open in browser.
-- `GitLink blame`: generate the `/blame` url and copy to clipboard.
-- `GitLink! blame`: generate the `/blame` url and open in browser.
+- `GitLink`: copy the `/blob` url to clipboard.
+- `GitLink!`: open the `/blob` url in browser.
+- `GitLink blame`: copy the `/blame` url to clipboard.
+- `GitLink! blame`: open the `/blame` url in browser.
 
 There're two **routers** provided:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ PRs are welcomed for other git host websites!
 - [Usage](#usage)
 - [Configuration](#configuration)
   - [Highlighting](#highlighting)
-  - [Self-Host Git Hosts](#self-host-git-hosts)
+  - [Self-host Git Hosts](#self-host-git-hosts)
   - [Fully Customize Urls](#fully-customize-urls)
 - [Highlight Group](#highlight-group)
 - [Development](#development)

--- a/README.md
+++ b/README.md
@@ -165,8 +165,7 @@ require('gitlinker').setup({
   command = {
     -- to copy link to clipboard, use: 'GitLink'
     -- to open link in browser, use bang: 'GitLink!'
-    -- to use blame router, use: 'GitLink blame'
-    -- to use browse router, use: 'GitLink browse' (which is the default router)
+    -- to use blame router, use: 'GitLink blame' and 'GitLink! blame'
     name = "GitLink",
     desc = "Generate git permanent link",
   },
@@ -242,7 +241,7 @@ require('gitlinker').setup({
 
 ### Highlighting
 
-To create your own highlighting, please use:
+To create your own highlighting, please use below config before setup this plugin:
 
 ```lua
 -- lua
@@ -256,7 +255,7 @@ hi link NvimGitLinkerHighlightTextObject Constant
 
 > Also see [Highlight Group](#highlight-group).
 
-### Self-Host Git Hosts
+### Self-host Git Hosts
 
 For self-host git host websites, please add more bindings in `router` option.
 
@@ -285,11 +284,7 @@ There're 3 groups of builtin APIs you can directly use:
 
 ### Fully Customize Urls
 
-<details>
-<summary><i>Click here to see how to fully customize urls</i></summary>
-<br/>
-
-To fully customize url generation, please refer to the implementation of [routers.lua](https://github.com/linrongbin16/gitlinker.nvim/blob/master/lua/gitlinker/routers.lua), a router is simply construct the string from below components:
+To fully customize url generation, please refer to the implementation of [routers.lua](https://github.com/linrongbin16/gitlinker.nvim/blob/master/lua/gitlinker/routers.lua), a router is simply construct the url string from below components:
 
 - `protocol`: `git@`, `ssh://git@`, `https`, etc.
 - `host`: `github.com`, `gitlab.com`, `bitbucket.org`, etc.
@@ -326,12 +321,10 @@ local function your_router(lk)
     .. lk.file
     .. (string_endswith(lk.file, ".md") and "?plain=1" or "")
   -- line range: start line number, end line number
-  if type(lk.lstart) == "number" then
-    builder = builder .. string.format("&lines=%d", lk.lstart)
-    if type(lk.lend) == "number" and lk.lend > lk.lstart then
-      builder = builder
-        .. string.format("&lines-count=%d", lk.lend - lk.lstart + 1)
-    end
+  builder = builder .. string.format("&lines=%d", lk.lstart)
+  if lk.lend > lk.lstart then
+    builder = builder
+      .. string.format("&lines-count=%d", lk.lend - lk.lstart + 1)
   end
   return builder
 end
@@ -345,9 +338,9 @@ require("gitlinker").setup({
 })
 ```
 
-Quite a lot of engineering effort, isn't it? You can also use the url template, which should be easier to define the url schema.
+Quite a lot of engineering effort, isn't it? You can also use the url template, which should be easier to define the url schema:
 
-The url template is also the default implementation of builtin routers (see `router` option in [Configuration](#configuration)), but the error message could be confusing if there's any syntax issue:
+> The url template is also the default implementation of builtin routers (see `router` option in [Configuration](#configuration)), but the error message could be confusing if there's any syntax issue.
 
 ```lua
 require("gitlinker").setup({
@@ -373,13 +366,10 @@ The available variables are the same with the `lk` parameter passing to hook fun
 - `_A.HOST`: `github.com`, `gitlab.com`, `bitbucket.org`, etc.
 - `_A.USER`: `linrongbin16` (for this plugin), `neovim` (for [neovim](https://github.com/neovim/neovim)), etc.
 - `_A.REPO`: `gitlinker.nvim`, `neovim`, etc.
-  - **Note**: for easier writing, the `.git` suffix has been removed.
+  - **Note: for easier writing, the `.git` suffix has been removed.**
 - `_A.REV`: git commit, e.g. `dbf3922382576391fbe50b36c55066c1768b08b6`.
 - `_A.FILE`: file name, e.g. `lua/gitlinker/routers.lua`.
 - `_A.LSTART`/`_A.LEND`: start/end line numbers, e.g. `#L37-L156`.
-  - **Note**: for easier writing, the `_A.LEND` will always exists so no NPE will be throwed.
-
-</details>
 
 ## Highlight Group
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ PRs are welcomed for other git host websites!
 ## Break Changes & Updates
 
 1. Break Changes:
-   - Drop off default key mappings, provide `GitLink` command.
+   - Provide `GitLink` command instead of default key mappings.
 2. New Features:
    - Windows (+wsl) support.
    - Respect ssh host alias.


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
