### PR TITLE
perf(fetch): detect git remote has `fetch` configured before check remote branches

### DIFF
--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -186,6 +186,11 @@ local function _is_rev_in_remote(revspec, remote)
       return true
     end
   end
+  logger.debug(
+    "|git._is_rev_in_remote| remote(%s) not match branches:%s",
+    vim.inspect(remote),
+    vim.inspect(output)
+  )
   return false
 end
 
@@ -242,10 +247,6 @@ local function get_closest_remote_compatible_rev(remote)
 
   -- try upstream branch HEAD (a.k.a @{u})
   local upstream_rev = _get_rev("@{u}")
-  logger.debug(
-    "|git.get_closest_remote_compatible_rev| running _get_rev:%s",
-    vim.inspect(upstream_rev)
-  )
   if upstream_rev then
     return upstream_rev
   end

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -40,23 +40,23 @@ local function _parse_remote_url(remote_url)
     )
   end
 
-  logger.debug(
-    "|gitlinker.linker - _parse_remote_url| 1. remote_url:%s, proto_pos:%s (%s)",
-    vim.inspect(remote_url),
-    vim.inspect(proto_pos),
-    vim.inspect(proto)
-  )
+  -- logger.debug(
+  --   "|gitlinker.linker - _parse_remote_url| 1. remote_url:%s, proto_pos:%s (%s)",
+  --   vim.inspect(remote_url),
+  --   vim.inspect(proto_pos),
+  --   vim.inspect(proto)
+  -- )
   if type(proto_pos) == "number" and proto_pos > 0 then
     protocol_end_pos = proto_pos + string.len(proto) - 1
     protocol = remote_url:sub(1, protocol_end_pos)
-    logger.debug(
-      "|gitlinker.linker - _parse_remote_url| 2. remote_url:%s, proto_pos:%s (%s), protocol_end_pos:%s (%s)",
-      vim.inspect(remote_url),
-      vim.inspect(proto_pos),
-      vim.inspect(proto),
-      vim.inspect(protocol_end_pos),
-      vim.inspect(protocol)
-    )
+    -- logger.debug(
+    --   "|gitlinker.linker - _parse_remote_url| 2. remote_url:%s, proto_pos:%s (%s), protocol_end_pos:%s (%s)",
+    --   vim.inspect(remote_url),
+    --   vim.inspect(proto_pos),
+    --   vim.inspect(proto),
+    --   vim.inspect(protocol_end_pos),
+    --   vim.inspect(protocol)
+    -- )
     local first_slash_pos = utils.string_find(
       remote_url,
       "/",
@@ -77,16 +77,16 @@ local function _parse_remote_url(remote_url)
       )
     end
     host = remote_url:sub(protocol_end_pos + 1, host_end_pos - 1)
-    logger.debug(
-      "|gitlinker.linker - _parse_remote_url| last. remote_url:%s, proto_pos:%s (%s), protocol_end_pos:%s (%s), host_end_pos:%s (%s)",
-      vim.inspect(remote_url),
-      vim.inspect(proto_pos),
-      vim.inspect(proto),
-      vim.inspect(protocol_end_pos),
-      vim.inspect(protocol),
-      vim.inspect(host_end_pos),
-      vim.inspect(host)
-    )
+    -- logger.debug(
+    --   "|gitlinker.linker - _parse_remote_url| last. remote_url:%s, proto_pos:%s (%s), protocol_end_pos:%s (%s), host_end_pos:%s (%s)",
+    --   vim.inspect(remote_url),
+    --   vim.inspect(proto_pos),
+    --   vim.inspect(proto),
+    --   vim.inspect(protocol_end_pos),
+    --   vim.inspect(protocol),
+    --   vim.inspect(host_end_pos),
+    --   vim.inspect(host)
+    -- )
   end
 
   local user_end_pos = utils.string_find(remote_url, "/", host_end_pos + 1)
@@ -96,7 +96,7 @@ local function _parse_remote_url(remote_url)
   user = remote_url:sub(host_end_pos + 1, user_end_pos - 1)
   repo = remote_url:sub(user_end_pos + 1)
   local result = { protocol = protocol, host = host, user = user, repo = repo }
-  logger.debug("linker._parse_remote_url| result:%s", vim.inspect(result))
+  -- logger.debug("linker._parse_remote_url| result:%s", vim.inspect(result))
   return result
 end
 


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Tasks

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
