### PR TITLE
feat: codeberg router

### DIFF
--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -52,6 +52,14 @@ local Defaults = {
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
+      -- example: https://codeberg.org/bagnaram/dotfiles/src/branch/master/Makefile
+      ["^codeberg%.org"] = "https://codeberg.org/"
+        .. "{_A.USER}/"
+        .. "{_A.REPO}/src/"
+        .. "{_A.REV}/"
+        .. "{_A.FILE}"
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) and '?display=source' or '')}",
     },
     blame = {
       -- example: https://github.com/linrongbin16/gitlinker.nvim/blame/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
@@ -79,6 +87,14 @@ local Defaults = {
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
+      -- example: https://codeberg.org/bagnaram/dotfiles/blame/commit/83a43b616cb6b5da976f6d64460b7af5839c9d21/Makefile#L84-L86
+      ["^codeberg%.org"] = "https://codeberg.org/"
+        .. "{_A.USER}/"
+        .. "{_A.REPO}/blame/"
+        .. "{_A.REV}/"
+        .. "{_A.FILE}"
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) and '?display=source' or '')}",
     },
   },
 

--- a/lua/gitlinker/routers.lua
+++ b/lua/gitlinker/routers.lua
@@ -108,6 +108,13 @@ local function bitbucket_browse(lk)
   local builder = Builder:new(lk, lines_range)
   return builder:build("src")
 end
+--
+--- @param lk gitlinker.Linker
+--- @return string
+local function codeberg_browse(lk)
+  local builder = Builder:new(lk, LC_range)
+  return builder:build("src")
+end
 
 --- @param lk gitlinker.Linker
 --- @return string
@@ -130,6 +137,13 @@ local function bitbucket_blame(lk)
   return builder:build("annotate")
 end
 
+--- @param lk gitlinker.Linker
+--- @return string
+local function codeberg_blame(lk)
+  local builder = Builder:new(lk, lines_range)
+  return builder:build("blame")
+end
+
 local M = {
   -- Builder
   Builder = Builder,
@@ -142,11 +156,13 @@ local M = {
   github_browse = github_browse,
   gitlab_browse = gitlab_browse,
   bitbucket_browse = bitbucket_browse,
+  codeberg_browse = codeberg_browse,
 
   -- blame: `/blame`, `/annotate`
   github_blame = github_blame,
   gitlab_blame = gitlab_blame,
   bitbucket_blame = bitbucket_blame,
+  codeberg_blame = codeberg_blame,
 }
 
 return M


### PR DESCRIPTION
New Codeburg router utilizing Builder:new

# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [x] linux

## Tasks

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
