### PR TITLE
feat(bare/worktree): only check remote branches if remote has 'fetch' config

### DIFF
--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -1,4 +1,5 @@
 local range = require("gitlinker.range")
+local LogLevels = require("gitlinker.logger").LogLevels
 local logger = require("gitlinker.logger")
 local linker = require("gitlinker.linker")
 local highlight = require("gitlinker.highlight")
@@ -402,7 +403,7 @@ local function setup(opts)
 
   -- logger
   logger.setup({
-    level = Configs.debug and "DEBUG" or "INFO",
+    level = Configs.debug and LogLevels.DEBUG or LogLevels.INFO,
     console_log = Configs.console_log,
     file_log = Configs.file_log,
   })

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -330,15 +330,14 @@ local function link(opts)
   return url
 end
 
---- @param opts gitlinker.Options?
+--- @param opts gitlinker.Options
 --- @return gitlinker.Options
 local function _merge_routers(opts)
   -- browse
   local browse_routers = vim.deepcopy(Defaults.router.browse)
   local browse_router_binding_opts = {}
   if
-    type(opts) == "table"
-    and type(opts.router_binding) == "table"
+    type(opts.router_binding) == "table"
     and type(opts.router_binding.browse) == "table"
   then
     deprecation.notify(
@@ -347,9 +346,7 @@ local function _merge_routers(opts)
     browse_router_binding_opts = vim.deepcopy(opts.router_binding.browse)
   end
   local browse_router_opts = (
-    type(opts) == "table"
-    and type(opts.router) == "table"
-    and type(opts.router.browse) == "table"
+    type(opts.router) == "table" and type(opts.router.browse) == "table"
   )
       and vim.deepcopy(opts.router.browse)
     or {}
@@ -365,8 +362,7 @@ local function _merge_routers(opts)
   local blame_routers = vim.deepcopy(Defaults.router.blame)
   local blame_router_binding_opts = {}
   if
-    type(opts) == "table"
-    and type(opts.router_binding) == "table"
+    type(opts.router_binding) == "table"
     and type(opts.router_binding.blame) == "table"
   then
     deprecation.notify(
@@ -375,9 +371,7 @@ local function _merge_routers(opts)
     blame_router_binding_opts = vim.deepcopy(opts.router_binding.blame)
   end
   local blame_router_opts = (
-    type(opts) == "table"
-    and type(opts.router) == "table"
-    and type(opts.router.blame) == "table"
+    type(opts.router) == "table" and type(opts.router.blame) == "table"
   )
       and vim.deepcopy(opts.router.blame)
     or {}
@@ -397,19 +391,9 @@ end
 
 --- @param opts gitlinker.Options?
 local function setup(opts)
-  local fp = io.open("gitlinker.log", "a")
-  if fp then
-    fp:write(string.format("opts: %s\n", vim.inspect(opts)))
-  end
-  fp:close()
-  local router_configs = _merge_routers(opts)
+  local router_configs = _merge_routers(opts or {})
   Configs = vim.tbl_deep_extend("force", vim.deepcopy(Defaults), opts or {})
   Configs.router = router_configs
-  local fp = io.open("gitlinker.log", "a")
-  if fp then
-    fp:write(string.format("gitlinker.Configs: %s\n", vim.inspect(Configs)))
-  end
-  fp:close()
 
   -- logger
   logger.setup({

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -397,9 +397,19 @@ end
 
 --- @param opts gitlinker.Options?
 local function setup(opts)
+  local fp = io.open("gitlinker.log", "a")
+  if fp then
+    fp:write(string.format("opts: %s\n", vim.inspect(opts)))
+  end
+  fp:close()
   local router_configs = _merge_routers(opts)
   Configs = vim.tbl_deep_extend("force", vim.deepcopy(Defaults), opts or {})
   Configs.router = router_configs
+  local fp = io.open("gitlinker.log", "a")
+  if fp then
+    fp:write(string.format("gitlinker.Configs: %s\n", vim.inspect(Configs)))
+  end
+  fp:close()
 
   -- logger
   logger.setup({

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -271,8 +271,10 @@ local function get_closest_remote_compatible_rev(remote)
     return upstream_rev
   end
 
+  local remote_fetch_configured = _has_remote_fetch_config(remote)
+
   -- try HEAD
-  if _has_remote_fetch_config(remote) then
+  if remote_fetch_configured then
     if _is_rev_in_remote("HEAD", remote) then
       local head_rev = _get_rev("HEAD")
       if head_rev then
@@ -287,7 +289,7 @@ local function get_closest_remote_compatible_rev(remote)
   end
 
   -- try last 50 parent commits
-  if _has_remote_fetch_config(remote) then
+  if remote_fetch_configured then
     for i = 1, 50 do
       local revspec = "HEAD~" .. i
       if _is_rev_in_remote(revspec, remote) then

--- a/lua/gitlinker/logger.lua
+++ b/lua/gitlinker/logger.lua
@@ -74,9 +74,8 @@ local function log(level, msg)
       for _, line in ipairs(msg_lines) do
         fp:write(
           string.format(
-            "%s %s [%s]: %s\n",
+            "%s [%s]: %s\n",
             os.date("%Y-%m-%d %H:%M:%S"),
-            Configs.level,
             LogLevelNames[level],
             line
           )

--- a/lua/gitlinker/logger.lua
+++ b/lua/gitlinker/logger.lua
@@ -72,12 +72,6 @@ local function log(level, msg)
   local msg_lines = vim.split(msg, "\n", { plain = true })
   if Configs.console_log and level >= LogLevels.INFO then
     local msg_chunks = {}
-    -- local prefix = ""
-    -- if level == LogLevels.ERROR then
-    --     prefix = "error! "
-    -- elseif level == LogLevels.WARN then
-    --     prefix = "warning! "
-    -- end
     for _, line in ipairs(msg_lines) do
       table.insert(msg_chunks, {
         string.format("[gitlinker] %s", --[[prefix,]] line),

--- a/lua/gitlinker/logger.lua
+++ b/lua/gitlinker/logger.lua
@@ -132,6 +132,7 @@ local function ensure(cond, fmt, ...)
 end
 
 local M = {
+  LogLevels = LogLevels,
   setup = setup,
   debug = debug,
   info = info,

--- a/lua/gitlinker/logger.lua
+++ b/lua/gitlinker/logger.lua
@@ -28,12 +28,10 @@ local PathSeperator = (vim.fn.has("win32") > 0 or vim.fn.has("win64") > 0)
     and "\\"
   or "/"
 
-local Configs = {
+local Defaults = {
   level = LogLevels.INFO,
   console_log = true,
   file_log = false,
-  file_log_dir = vim.fn.stdpath("data"),
-  file_log_name = "gitlinker.log",
   _file_log_path = string.format(
     "%s%s%s",
     vim.fn.stdpath("data"),
@@ -42,21 +40,11 @@ local Configs = {
   ),
 }
 
+local Configs = {}
+
 --- @param opts gitlinker.Options?
 local function setup(opts)
-  Configs = vim.tbl_deep_extend("force", vim.deepcopy(Configs), opts or {})
-  if type(Configs.level) == "string" then
-    Configs.level = LogLevels[Configs.level]
-  end
-
-  if Configs.file_log then
-    Configs._file_log_path = string.format(
-      "%s%s%s",
-      Configs.file_log_dir,
-      (vim.fn.has("win32") > 0 or vim.fn.has("win64") > 0) and "\\" or "/",
-      Configs.file_log_name
-    )
-  end
+  Configs = vim.tbl_deep_extend("force", vim.deepcopy(Defaults), opts or {})
   assert(
     type(Configs.level) == "number" and LogHighlights[Configs.level] ~= nil
   )
@@ -86,8 +74,9 @@ local function log(level, msg)
       for _, line in ipairs(msg_lines) do
         fp:write(
           string.format(
-            "%s [%s]: %s\n",
+            "%s %s [%s]: %s\n",
             os.date("%Y-%m-%d %H:%M:%S"),
+            Configs.level,
             LogLevelNames[level],
             line
           )

--- a/test/git_spec.lua
+++ b/test/git_spec.lua
@@ -8,14 +8,13 @@ describe("git", function()
   before_each(function()
     vim.api.nvim_command("cd " .. cwd)
     vim.opt.swapfile = false
-    local logger = require("gitlinker.logger")
-    logger.setup()
     vim.cmd([[ edit lua/gitlinker.lua ]])
   end)
 
+  local LogLevels = require("gitlinker.logger").LogLevels
   local logger = require("gitlinker.logger")
   logger.setup({
-    level = "DEBUG",
+    level = LogLevels.DEBUG,
     console_log = true,
     file_log = true,
   })

--- a/test/logger_spec.lua
+++ b/test/logger_spec.lua
@@ -9,9 +9,10 @@ describe("logger", function()
     vim.api.nvim_command("cd " .. cwd)
   end)
 
+  local LogLevels = require("gitlinker.logger").LogLevels
   local logger = require("gitlinker.logger")
   logger.setup({
-    level = "DEBUG",
+    level = LogLevels.DEBUG,
     console_log = true,
     file_log = true,
   })


### PR DESCRIPTION
… configured

# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Tasks

- [x] Use `GitLink` to copy git link.
- [x] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
