### PR TITLE
perf(routers): always add 'plain=1' for github

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
-      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L3-L4
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L5-L6
       ["^codeberg%.org"] = "https://codeberg.org/"
         .. "{_A.USER}/"
         .. "{_A.REPO}/blame/commit/"

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/src/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/src/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#lines-3:4
       ["^bitbucket%.org"] = "https://bitbucket.org/"
         .. "{_A.USER}/"
         .. "{_A.REPO}/src/"
@@ -244,7 +244,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
-      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L5-L6
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#lines-3:4
       ["^codeberg%.org"] = "https://codeberg.org/"
         .. "{_A.USER}/"
         .. "{_A.REPO}/blame/commit/"

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
-      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#lines-3:4
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L3-L4
       ["^codeberg%.org"] = "https://codeberg.org/"
         .. "{_A.USER}/"
         .. "{_A.REPO}/blame/commit/"

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/annotate/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/annotate/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#lines-3:4
       ["^bitbucket%.org"] = "https://bitbucket.org/"
         .. "{_A.USER}/"
         .. "{_A.REPO}/annotate/"

--- a/README.md
+++ b/README.md
@@ -182,8 +182,7 @@ require('gitlinker').setup({
         .. "{_A.USER}/"
         .. "{_A.REPO}/blob/"
         .. "{_A.REV}/"
-        .. "{_A.FILE}"
-        .. "{(string.len(_A.FILE) >= 3 and _A.FILE:sub(#_A.FILE-2) == '.md') and '?plain=1' or ''}" -- '?plain=1'
+        .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
       -- example: https://gitlab.com/linrongbin16/gitlinker.nvim/blob/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
@@ -194,7 +193,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/src/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#lines-3:4
+      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/src/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
       ["^bitbucket%.org"] = "https://bitbucket.org/"
         .. "{_A.USER}/"
         .. "{_A.REPO}/src/"
@@ -207,15 +206,14 @@ require('gitlinker').setup({
         .. "{_A.USER}/"
         .. "{_A.REPO}/src/commit/"
         .. "{_A.REV}/"
-        .. "{_A.FILE}"
-        .. "{(string.len(_A.FILE) >= 3 and _A.FILE:sub(#_A.FILE-2) == '.md') and '?display=source' or ''}" -- '?display=source'
+        .. "{_A.FILE}?display=source" -- '?display=source'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
       -- example:
       -- main repo: https://git.samba.org/?p=samba.git;a=blob;f=wscript;hb=83e8971c0f1c1db8c3574f83107190ac1ac23db0#l6
       -- dev repo: https://git.samba.org/?p=bbaumbach/samba.git;a=blob;f=wscript;hb=8de348e9d025d336a7985a9025fe08b7096c0394#l7
       ["^git%.samba%.org"] = "https://git.samba.org/?p="
-        .. "{string.len(_A.USER) > 0 and (_A.USER .. '/') or ''}" -- 'p=samba.git' or 'p=bbaumbach/samba.git'
+        .. "{string.len(_A.USER) > 0 and (_A.USER .. '/') or ''}" -- 'p=samba.git;' or 'p=bbaumbach/samba.git;'
         .. "{_A.REPO .. '.git'};a=blob;"
         .. "f={_A.FILE};"
         .. "hb={_A.REV}"
@@ -227,8 +225,7 @@ require('gitlinker').setup({
         .. "{_A.USER}/"
         .. "{_A.REPO}/blame/"
         .. "{_A.REV}/"
-        .. "{_A.FILE}"
-        .. "{(string.len(_A.FILE) >= 3 and _A.FILE:sub(#_A.FILE-2) == '.md') and '?plain=1' or ''}"
+        .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
       -- example: https://gitlab.com/linrongbin16/gitlinker.nvim/blame/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
@@ -239,7 +236,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/annotate/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#lines-3:4
+      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/annotate/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
       ["^bitbucket%.org"] = "https://bitbucket.org/"
         .. "{_A.USER}/"
         .. "{_A.REPO}/annotate/"
@@ -252,7 +249,7 @@ require('gitlinker').setup({
         .. "{_A.USER}/"
         .. "{_A.REPO}/blame/commit/"
         .. "{_A.REV}/"
-        .. "{_A.FILE}"
+        .. "{_A.FILE}?display=source" -- '?display=source'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
     },

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -95,7 +95,7 @@ local Defaults = {
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
-      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L3-L4
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L5-L6
       ["^codeberg%.org"] = "https://codeberg.org/"
         .. "{_A.USER}/"
         .. "{_A.REPO}/blame/commit/"

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -33,8 +33,7 @@ local Defaults = {
         .. "{_A.USER}/"
         .. "{_A.REPO}/blob/"
         .. "{_A.REV}/"
-        .. "{_A.FILE}"
-        .. "{(string.len(_A.FILE) >= 3 and _A.FILE:sub(#_A.FILE-2) == '.md') and '?plain=1' or ''}" -- '?plain=1'
+        .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
       -- example: https://gitlab.com/linrongbin16/gitlinker.nvim/blob/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
@@ -58,8 +57,7 @@ local Defaults = {
         .. "{_A.USER}/"
         .. "{_A.REPO}/src/commit/"
         .. "{_A.REV}/"
-        .. "{_A.FILE}"
-        .. "{(string.len(_A.FILE) >= 3 and _A.FILE:sub(#_A.FILE-2) == '.md') and '?display=source' or ''}" -- '?display=source'
+        .. "{_A.FILE}?display=source" -- '?display=source'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
       -- example:
@@ -78,8 +76,7 @@ local Defaults = {
         .. "{_A.USER}/"
         .. "{_A.REPO}/blame/"
         .. "{_A.REV}/"
-        .. "{_A.FILE}"
-        .. "{(string.len(_A.FILE) >= 3 and _A.FILE:sub(#_A.FILE-2) == '.md') and '?plain=1' or ''}"
+        .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
       -- example: https://gitlab.com/linrongbin16/gitlinker.nvim/blame/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
@@ -103,7 +100,7 @@ local Defaults = {
         .. "{_A.USER}/"
         .. "{_A.REPO}/blame/commit/"
         .. "{_A.REV}/"
-        .. "{_A.FILE}"
+        .. "{_A.FILE}?display=source" -- '?display=source'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
     },

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -87,7 +87,7 @@ local Defaults = {
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/annotate/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/annotate/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#lines-3:4
       ["^bitbucket%.org"] = "https://bitbucket.org/"
         .. "{_A.USER}/"
         .. "{_A.REPO}/annotate/"

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -95,7 +95,7 @@ local Defaults = {
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
-      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L5-L6
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L3-L4
       ["^codeberg%.org"] = "https://codeberg.org/"
         .. "{_A.USER}/"
         .. "{_A.REPO}/blame/commit/"

--- a/lua/gitlinker/routers.lua
+++ b/lua/gitlinker/routers.lua
@@ -25,6 +25,36 @@ local function LC_range(r)
   return tmp
 end
 
+--- @alias gitlinker.RangeStringify fun(r:gitlinker.Range?):string?
+--- @param r gitlinker.Range?
+--- @return string?
+local function github_LC_range(r)
+  if not range.is_range(r) then
+    return nil
+  end
+  assert(r ~= nil)
+  local tmp = string.format([[?plain=1#L%d]], r.lstart)
+  if type(r.lend) == "number" and r.lend > r.lstart then
+    tmp = tmp .. string.format([[-L%d]], r.lend)
+  end
+  return tmp
+end
+
+--- @alias gitlinker.RangeStringify fun(r:gitlinker.Range?):string?
+--- @param r gitlinker.Range?
+--- @return string?
+local function codeberg_LC_range(r)
+  if not range.is_range(r) then
+    return nil
+  end
+  assert(r ~= nil)
+  local tmp = string.format([[?display=source#L%d]], r.lstart)
+  if type(r.lend) == "number" and r.lend > r.lstart then
+    tmp = tmp .. string.format([[-L%d]], r.lend)
+  end
+  return tmp
+end
+
 --- @param r gitlinker.Range?
 --- @return string?
 local function lines_range(r)
@@ -114,7 +144,7 @@ end
 --- @param lk gitlinker.Linker
 --- @return string
 local function github_browse(lk)
-  local builder = Builder:new(lk, LC_range)
+  local builder = Builder:new(lk, github_LC_range)
   return builder:build("blob")
 end
 
@@ -135,7 +165,7 @@ end
 --- @param lk gitlinker.Linker
 --- @return string
 local function codeberg_browse(lk)
-  local builder = Builder:new(lk, LC_range)
+  local builder = Builder:new(lk, codeberg_LC_range)
   return builder:build("src/commit")
 end
 
@@ -146,7 +176,7 @@ end
 --- @param lk gitlinker.Linker
 --- @return string
 local function github_blame(lk)
-  local builder = Builder:new(lk, LC_range)
+  local builder = Builder:new(lk, github_LC_range)
   return builder:build("blame")
 end
 
@@ -167,7 +197,7 @@ end
 --- @param lk gitlinker.Linker
 --- @return string
 local function codeberg_blame(lk)
-  local builder = Builder:new(lk, LC_range)
+  local builder = Builder:new(lk, codeberg_LC_range)
   return builder:build("blame/commit")
 end
 

--- a/lua/gitlinker/routers.lua
+++ b/lua/gitlinker/routers.lua
@@ -11,6 +11,7 @@ local logger = require("gitlinker.logger")
 local Builder = {}
 
 --- @alias gitlinker.RangeStringify fun(r:gitlinker.Range?):string?
+
 --- @param r gitlinker.Range?
 --- @return string?
 local function LC_range(r)
@@ -25,7 +26,6 @@ local function LC_range(r)
   return tmp
 end
 
---- @alias gitlinker.RangeStringify fun(r:gitlinker.Range?):string?
 --- @param r gitlinker.Range?
 --- @return string?
 local function github_LC_range(r)
@@ -40,7 +40,6 @@ local function github_LC_range(r)
   return tmp
 end
 
---- @alias gitlinker.RangeStringify fun(r:gitlinker.Range?):string?
 --- @param r gitlinker.Range?
 --- @return string?
 local function codeberg_LC_range(r)

--- a/test/gitlinker_spec.lua
+++ b/test/gitlinker_spec.lua
@@ -19,7 +19,7 @@ describe("gitlinker", function()
             .. "{_A.USER}/"
             .. "{_A.REPO}/blob/"
             .. "{_A.REV}/"
-            .. "{_A.FILE}"
+            .. "{_A.FILE}?plain=1"
             .. "#L{_A.LSTART}"
             .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
         },
@@ -28,7 +28,7 @@ describe("gitlinker", function()
             .. "{_A.USER}/"
             .. "{_A.REPO}/blame/"
             .. "{_A.REV}/"
-            .. "{_A.FILE}"
+            .. "{_A.FILE}?plain=1"
             .. "#L{_A.LSTART}"
             .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
         },
@@ -143,7 +143,7 @@ describe("gitlinker", function()
       local actual = gitlinker._browse(lk)
       assert_eq(
         actual,
-        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L13-L47"
+        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?plain=1#L13-L47"
       )
       assert_eq(actual, routers.github_browse(lk))
     end)
@@ -163,7 +163,7 @@ describe("gitlinker", function()
       local actual = gitlinker._browse(lk)
       assert_eq(
         actual,
-        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1"
+        "https://github.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?plain=1#L1"
       )
       assert_eq(actual, routers.github_browse(lk))
     end)
@@ -184,7 +184,7 @@ describe("gitlinker", function()
       local actual = gitlinker._browse(lk)
       assert_eq(
         actual,
-        "https://git.xyz.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L13-L47"
+        "https://git.xyz.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?plain=1#L13-L47"
       )
       assert_eq(actual, routers.github_browse(lk))
     end)
@@ -205,7 +205,7 @@ describe("gitlinker", function()
       local actual = gitlinker._browse(lk)
       assert_eq(
         actual,
-        "https://git.xyz.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1"
+        "https://git.xyz.com/linrongbin16/gitlinker.nvim/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?plain=1#L1"
       )
       assert_eq(actual, routers.github_browse(lk))
     end)
@@ -305,7 +305,7 @@ describe("gitlinker", function()
       local actual = gitlinker._browse(lk)
       assert_eq(
         actual,
-        "https://codeberg.org/linrongbin16/gitlinker.nvim/src/commit/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L17"
+        "https://codeberg.org/linrongbin16/gitlinker.nvim/src/commit/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?display=source#L17"
       )
       assert_eq(actual, routers.codeberg_browse(lk))
     end)
@@ -325,7 +325,7 @@ describe("gitlinker", function()
       local actual = gitlinker._browse(lk)
       assert_eq(
         actual,
-        "https://codeberg.org/linrongbin16/gitlinker.nvim/src/commit/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L27-L53"
+        "https://codeberg.org/linrongbin16/gitlinker.nvim/src/commit/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?display=source#L27-L53"
       )
       assert_eq(actual, routers.codeberg_browse(lk))
     end)
@@ -347,7 +347,7 @@ describe("gitlinker", function()
       local actual = gitlinker._blame(lk)
       assert_eq(
         actual,
-        "https://github.com/linrongbin16/gitlinker.nvim/blame/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1"
+        "https://github.com/linrongbin16/gitlinker.nvim/blame/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?plain=1#L1"
       )
       assert_eq(actual, routers.github_blame(lk))
     end)
@@ -367,7 +367,7 @@ describe("gitlinker", function()
       local actual = gitlinker._blame(lk)
       assert_eq(
         actual,
-        "https://github.com/linrongbin16/gitlinker.nvim/blame/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L1-L2"
+        "https://github.com/linrongbin16/gitlinker.nvim/blame/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?plain=1#L1-L2"
       )
       assert_eq(actual, routers.github_blame(lk))
     end)
@@ -467,7 +467,7 @@ describe("gitlinker", function()
       local actual = gitlinker._blame(lk)
       assert_eq(
         actual,
-        "https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L13"
+        "https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?display=source#L13"
       )
       assert_eq(actual, routers.codeberg_blame(lk))
     end)
@@ -488,7 +488,7 @@ describe("gitlinker", function()
       local actual = gitlinker._blame(lk)
       assert_eq(
         actual,
-        "https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua#L13-L21"
+        "https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?display=source#L13-L21"
       )
       assert_eq(actual, routers.codeberg_blame(lk))
     end)


### PR DESCRIPTION
…down like rendering

# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
