### PR TITLE
feat(branch): provide `DEFAULT_BRANCH` and `CURRENT_BRANCH` components

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
 globals = { "vim", "describe", "before_each", "it", "assert" }
-max_line_length = 200
+max_line_length = 500
 unused = false
 unused_args = false

--- a/README.md
+++ b/README.md
@@ -425,18 +425,28 @@ The difference is: the main repo doesn't have the `user` component, it's just `h
 
 ### More Router Types
 
-You can even create your own router type (e.g. use the same engine with `browse`/`blame`), for example create the `master_branch` router type:
+You can even create your own router type (e.g. use the same engine with `browse`/`blame`), for example create the `default_branch` router type:
 
 ```lua
 require("gitlinker").setup({
   router = {
-    master_branch = {
+    default_branch = {
       ["^github%.com"] = "https://github.com/"
         .. "{_A.USER}/"
-        .. "{_A.REPO}/blob/master/" -- always 'master' branch
-        .. "{_A.FILE}"
-        .. "?&lines={_A.LSTART}"
-        .. "{_A.LEND > _A.LSTART and ('&lines-count=' .. _A.LEND - _A.LSTART + 1) or ''}",
+        .. "{_A.REPO}/blob/"
+        .. "{_A.DEFAULT_BRANCH}/" -- always 'master'/'main' branch
+        .. "{_A.FILE}?plain=1" -- '?plain=1'
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+    },
+    current_branch = {
+      ["^github%.com"] = "https://github.com/"
+        .. "{_A.USER}/"
+        .. "{_A.REPO}/blob/"
+        .. "{_A.CURRENT_BRANCH}/" -- always current branch
+        .. "{_A.FILE}?plain=1" -- '?plain=1'
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
     },
   },
 })
@@ -444,10 +454,15 @@ require("gitlinker").setup({
 
 Then use it just like `blame`:
 
+```vim
+GitLink default_branch
+GitLink current_branch
 ```
-GitLink master_branch
-GitLink! master_branch
-```
+
+Two more components are provided:
+
+- `lk.default_branch`(`_A.DEFAULT_BRANCH`): retrieved from `git rev-parse --abbrev-ref origin/HEAD`.
+- `lk.current_branch`(`_A.CURRENT_BRANCH`): retrieved from `git rev-parse --abbrev-ref HEAD`.
 
 ## Highlight Group
 

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -215,6 +215,12 @@ local function _url_template_engine(lk, template)
         LSTART = lk.lstart,
         LEND = (type(lk.lend) == "number" and lk.lend > lk.lstart) and lk.lend
           or lk.lstart,
+        DEFAULT_BRANCH = (type(lk.default_branch) == "string" and string.len(
+          lk.default_branch
+        ) > 0) and lk.default_branch or "",
+        CURRENT_BRANCH = (type(lk.current_branch) == "string" and string.len(
+          lk.current_branch
+        ) > 0) and lk.current_branch or "",
       })
       -- logger.debug(
       --   "|_url_template_engine| exp:%s, lk:%s, evaluated:%s",

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -573,6 +573,7 @@ local M = {
   link = link,
   _make_resolved_remote_url = _make_resolved_remote_url,
   _worker = _worker,
+  _router = _router,
   _browse = _browse,
   _blame = _blame,
   _merge_routers = _merge_routers,

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -393,6 +393,38 @@ local function get_branch_remote()
   return nil
 end
 
+--- @return string?
+local function get_default_branch()
+  local args = { "git", "rev-parse", "--abbrev-ref", "origin/HEAD" }
+  local result = cmd(args)
+  if type(result.stdout) ~= "table" or #result.stdout == 0 then
+    return nil
+  end
+  logger.debug(
+    "|git.get_default_branch| running %s: %s",
+    vim.inspect(args),
+    vim.inspect(result.stdout)
+  )
+  local splits =
+    vim.split(result.stdout[1], "/", { plain = true, trimempty = true })
+  return splits[#splits]
+end
+
+--- @return string?
+local function get_current_branch()
+  local args = { "git", "rev-parse", "--abbrev-ref", "HEAD" }
+  local result = cmd(args)
+  if type(result.stdout) ~= "table" or #result.stdout == 0 then
+    return nil
+  end
+  logger.debug(
+    "|git.get_current_branch| running %s: %s",
+    vim.inspect(args),
+    vim.inspect(result.stdout)
+  )
+  return result.stdout[1]
+end
+
 local M = {
   CmdResult = CmdResult,
   _get_remote = _get_remote,
@@ -405,6 +437,8 @@ local M = {
   get_closest_remote_compatible_rev = get_closest_remote_compatible_rev,
   get_branch_remote = get_branch_remote,
   resolve_host = resolve_host,
+  get_default_branch = get_default_branch,
+  get_current_branch = get_current_branch,
 }
 
 return M

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -118,7 +118,7 @@ local function _parse_remote_url(remote_url)
   return result
 end
 
---- @alias gitlinker.Linker {remote_url:string,protocol:string,host:string,host_delimiter:string,user:string,repo:string?,rev:string,file:string,lstart:integer,lend:integer,file_changed:boolean}
+--- @alias gitlinker.Linker {remote_url:string,protocol:string,host:string,host_delimiter:string,user:string,repo:string?,rev:string,file:string,lstart:integer,lend:integer,file_changed:boolean,default_branch:string?,current_branch:string?}
 --- @return gitlinker.Linker?
 local function make_linker()
   local root = git.get_root()
@@ -177,6 +177,9 @@ local function make_linker()
   --     vim.inspect(buf_path_on_cwd)
   -- )
 
+  local default_branch = git.get_default_branch()
+  local current_branch = git.get_current_branch()
+
   local o = {
     remote_url = remote_url,
     protocol = parsed_remote_url.protocol,
@@ -191,6 +194,8 @@ local function make_linker()
     ---@diagnostic disable-next-line: need-check-nil
     lend = nil,
     file_changed = file_changed,
+    default_branch = default_branch,
+    current_branch = current_branch,
   }
 
   logger.debug("|linker.make_linker| o:%s", vim.inspect(o))

--- a/test/gitlinker_spec.lua
+++ b/test/gitlinker_spec.lua
@@ -32,6 +32,24 @@ describe("gitlinker", function()
             .. "#L{_A.LSTART}"
             .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
         },
+        default_branch = {
+          ["^github%.com"] = "https://github.com/"
+            .. "{_A.USER}/"
+            .. "{_A.REPO}/blob/"
+            .. "{_A.DEFAULT_BRANCH}/" -- always 'master'/'main' branch
+            .. "{_A.FILE}?plain=1" -- '?plain=1'
+            .. "#L{_A.LSTART}"
+            .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+        },
+        current_branch = {
+          ["^github%.com"] = "https://github.com/"
+            .. "{_A.USER}/"
+            .. "{_A.REPO}/blob/"
+            .. "{_A.CURRENT_BRANCH}/" -- always current branch
+            .. "{_A.FILE}?plain=1" -- '?plain=1'
+            .. "#L{_A.LSTART}"
+            .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+        },
       },
     })
     vim.cmd([[ edit lua/gitlinker.lua ]])
@@ -743,6 +761,56 @@ describe("gitlinker", function()
         end
         assert_eq(blame_n, 4)
       end
+    end)
+  end)
+  describe("[user router types]", function()
+    it("default_branch", function()
+      local lk = {
+        remote_url = "https://github.com/linrongbin16/gitlinker.nvim.git",
+        protocol = "https://",
+        host = "github.com",
+        host_delimiter = "/",
+        user = "linrongbin16",
+        repo = "gitlinker.nvim.git",
+        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
+        file = "lua/gitlinker/logger.lua",
+        lstart = 13,
+        lend = 21,
+        file_changed = false,
+      }--[[@as gitlinker.Linker]]
+      local actual = gitlinker._router("default_branch", lk)
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/gitlinker.nvim/blob/master/lua/gitlinker/logger.lua?plain=1#L13-L21"
+      )
+    end)
+    it("current_branch", function()
+      local lk = {
+        remote_url = "https://github.com/linrongbin16/gitlinker.nvim.git",
+        protocol = "https://",
+        host = "github.com",
+        host_delimiter = "/",
+        user = "linrongbin16",
+        repo = "gitlinker.nvim.git",
+        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
+        file = "lua/gitlinker/logger.lua",
+        lstart = 13,
+        lend = 21,
+        file_changed = false,
+      }--[[@as gitlinker.Linker]]
+      local actual = gitlinker._router("current_branch", lk)
+      assert_true(
+        utils.string_startswith(
+          actual,
+          "https://github.com/linrongbin16/gitlinker.nvim/blob/"
+        )
+      )
+      assert_true(
+        utils.string_endswith(
+          actual,
+          "/lua/gitlinker/logger.lua?plain=1#L13-L21"
+        )
+      )
     end)
   end)
 end)

--- a/test/gitlinker_spec.lua
+++ b/test/gitlinker_spec.lua
@@ -777,6 +777,8 @@ describe("gitlinker", function()
         lstart = 13,
         lend = 21,
         file_changed = false,
+        default_branch = "master",
+        current_branch = "test",
       }--[[@as gitlinker.Linker]]
       local actual = gitlinker._router("default_branch", lk)
       assert_eq(
@@ -797,19 +799,13 @@ describe("gitlinker", function()
         lstart = 13,
         lend = 21,
         file_changed = false,
+        default_branch = "master",
+        current_branch = "current",
       }--[[@as gitlinker.Linker]]
       local actual = gitlinker._router("current_branch", lk)
-      assert_true(
-        utils.string_startswith(
-          actual,
-          "https://github.com/linrongbin16/gitlinker.nvim/blob/"
-        )
-      )
-      assert_true(
-        utils.string_endswith(
-          actual,
-          "/lua/gitlinker/logger.lua?plain=1#L13-L21"
-        )
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/gitlinker.nvim/blob/current/lua/gitlinker/logger.lua?plain=1#L13-L21"
       )
     end)
   end)

--- a/test/linker_spec.lua
+++ b/test/linker_spec.lua
@@ -106,6 +106,7 @@ describe("linker", function()
           lk.remote_url,
           "https://github.com/linrongbin16/gitlinker.nvim.git"
         )
+        assert_eq(lk.default_branch, "master")
       end
     end)
   end)

--- a/test/linker_spec.lua
+++ b/test/linker_spec.lua
@@ -107,6 +107,8 @@ describe("linker", function()
           "https://github.com/linrongbin16/gitlinker.nvim.git"
         )
         assert_eq(lk.default_branch, "master")
+        assert_eq(type(lk.current_branch), "string")
+        assert_true(string.len(lk.current_branch) >= 0)
       end
     end)
   end)

--- a/test/linker_spec.lua
+++ b/test/linker_spec.lua
@@ -87,6 +87,9 @@ describe("linker", function()
           lk.remote_url,
           "https://github.com/linrongbin16/gitlinker.nvim.git"
         )
+        assert_eq(lk.default_branch, "master")
+        assert_eq(type(lk.current_branch), "string")
+        assert_true(string.len(lk.current_branch) >= 0)
       end
     end)
     it("make with range", function()


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
