### PR TITLE
docs(config): two branch components

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,11 +463,6 @@ GitLink default_branch
 GitLink current_branch
 ```
 
-Two more components are provided:
-
-- `lk.default_branch`(`_A.DEFAULT_BRANCH`): retrieved from `git rev-parse --abbrev-ref origin/HEAD`.
-- `lk.current_branch`(`_A.CURRENT_BRANCH`): retrieved from `git rev-parse --abbrev-ref HEAD`.
-
 ## Highlight Group
 
 | Highlight Group                  | Default Group | Description                          |

--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ To fully customize url generation, please refer to the implementation of [router
 - `user`: `linrongbin16` (for this plugin), `neovim` (for [neovim](https://github.com/neovim/neovim)), etc.
 - `repo`: `gitlinker.nvim.git`, `neovim.git`, etc.
 - `rev`: git commit, e.g. `dbf3922382576391fbe50b36c55066c1768b08b6`.
+- `default_branch`: git default branch, `master`, `main`, etc, retrieved from `git rev-parse --abbrev-ref origin/HEAD`.
+- `current_branch`: git current branch, `feat-router-types`, etc, retrieved from `git rev-parse --abbrev-ref HEAD`.
 - `file`: file name, e.g. `lua/gitlinker/routers.lua`.
 - `lstart`/`lend`: start/end line numbers, e.g. `#L37-L156`.
 
@@ -397,6 +399,8 @@ The available variables are the same with the `lk` parameter passing to hook fun
 - `_A.REPO`: `gitlinker.nvim`, `neovim`, etc.
   - **Note:** for easier writing, the `.git` suffix has been removed.
 - `_A.REV`: git commit, e.g. `dbf3922382576391fbe50b36c55066c1768b08b6`.
+- `_A.DEFAULT_BRANCH`: git default branch, `master`, `main`, etc, retrieved from `git rev-parse --abbrev-ref origin/HEAD`.
+- `_A.CURRENT_BRANCH`: git current branch, `feat-router-types`, etc, retrieved from `git rev-parse --abbrev-ref HEAD`.
 - `_A.FILE`: file name, e.g. `lua/gitlinker/routers.lua`.
 - `_A.LSTART`/`_A.LEND`: start/end line numbers, e.g. `#L37-L156`.
 


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
