### PR TITLE
fix(default_branch): use real-time remote

### DIFF
--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -393,9 +393,11 @@ local function get_branch_remote()
   return nil
 end
 
+--- @param remote string
 --- @return string?
-local function get_default_branch()
-  local args = { "git", "rev-parse", "--abbrev-ref", "origin/HEAD" }
+local function get_default_branch(remote)
+  local args =
+    { "git", "rev-parse", "--abbrev-ref", string.format("%s/HEAD", remote) }
   local result = cmd(args)
   if type(result.stdout) ~= "table" or #result.stdout == 0 then
     return nil

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -177,7 +177,7 @@ local function make_linker()
   --     vim.inspect(buf_path_on_cwd)
   -- )
 
-  local default_branch = git.get_default_branch()
+  local default_branch = git.get_default_branch(remote)
   local current_branch = git.get_current_branch()
 
   local o = {


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
