### PR TITLE
feat(remote): support multiple remotes (origin/upstream)

### DIFF
--- a/.nvim.lua
+++ b/.nvim.lua
@@ -1,0 +1,4 @@
+vim.opt.tabstop = 2
+vim.opt.softtabstop = 2
+vim.opt.shiftwidth = 2
+

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ PRs are welcomed for other git host websites!
   - [Fully Customize Urls](#fully-customize-urls)
   - [GitWeb](#gitweb)
   - [More Router Types](#more-router-types)
-  - [Multiple Remotes](#multiple-remotes)
 - [Highlight Group](#highlight-group)
 - [Development](#development)
 - [Contribute](#contribute)
@@ -476,8 +475,6 @@ GitLink! default_branch " open default branch in browser
 GitLink current_branch  " copy current branch to clipboard
 GitLink! current_branch " open current branch in browser
 ```
-
-### Multiple Remotes
 
 ## Highlight Group
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,11 @@ To create your own highlighting, please use below config before setup this plugi
 
 ```lua
 -- lua
-vim.api.nvim_set_hl( 0, "NvimGitLinkerHighlightTextObject", { link = "Constant" })
+vim.api.nvim_set_hl(
+  0,
+  "NvimGitLinkerHighlightTextObject",
+  { link = "Constant" }
+)
 ```
 
 ```vim

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ PRs are welcomed for other git host websites!
   - [Fully Customize Urls](#fully-customize-urls)
   - [GitWeb](#gitweb)
   - [More Router Types](#more-router-types)
+  - [Multiple Remotes](#multiple-remotes)
 - [Highlight Group](#highlight-group)
 - [Development](#development)
 - [Contribute](#contribute)
@@ -119,6 +120,11 @@ There're two **routers** provided:
 
 - `browse`: generate the `/blob` urls (default router), also work for other git host websites, e.g. generate `/src` for bitbucket.org.
 - `blame`: generate the `/blame` urls, also work for other git host websites, e.g. generate `/annotate` for bitbucket.org.
+
+By default `GitLink` will use the first detected remote (usually `origin`), but if you need to specify other remotes with `remote=xxx` arguments. For example `upstream`, please use:
+
+- `GitLink (blame) remote=upstream`: copy upstream url to clipboard.
+- `GitLink! (blame) remote=upstream`: open upstream url in browser.
 
 <details>
 <summary><i>Click here to see recommended key mappings</i></summary>
@@ -306,11 +312,11 @@ require('gitlinker').setup({
 
 You can directly use below builtin APIs:
 
-- `github_browse`/`github_blame`: for [github.com](https://github.com/).
-- `gitlab_browse`/`gitlab_blame`: for [gitlab.com](https://gitlab.com/).
-- `bitbucket_browse`/`bitbucket_blame`: for [bitbucket.org](https://bitbucket.org/).
-- `codeberg_browse`/`codeberg_blame`: for [codeberg.org](https://codeberg.org/).
-- `samba_browse`: for [git.samba.org](https://git.samba.org/) (blame not support).
+- `github_browse`/`github_blame`: for github.com.
+- `gitlab_browse`/`gitlab_blame`: for gitlab.com.
+- `bitbucket_browse`/`bitbucket_blame`: for bitbucket.org.
+- `codeberg_browse`/`codeberg_blame`: for codeberg.org.
+- `samba_browse`: for git.samba.org (blame not support).
 
 ### Fully Customize Urls
 
@@ -426,7 +432,7 @@ protocol host            user      repo               file       rev            
 The difference is: the main repo doesn't have the `user` component, it's just `https://git.samba.org/?p=samba.git`. To support such case, `user` and `repo` components have a little bit different when facing the main repo:
 
 - `lk.user` (`_A.USER`): the value is `` (empty string).
-- `lk.repo` (`_A.REPO`): the value is `samba.git`.
+- `lk.repo` (`_A.REPO`): the value is `samba.git` (`_A.REPO` value is `samba`, suffix `.git` has been removed for easier writing url template).
 
 ### More Router Types
 
@@ -465,9 +471,13 @@ require("gitlinker").setup({
 Then use it just like `blame`:
 
 ```vim
-GitLink default_branch
-GitLink current_branch
+GitLink default_branch  " copy default branch to clipboard
+GitLink! default_branch " open default branch in browser
+GitLink current_branch  " copy current branch to clipboard
+GitLink! current_branch " open current branch in browser
 ```
+
+### Multiple Remotes
 
 ## Highlight Group
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ There're two **routers** provided:
 - `browse`: generate the `/blob` urls (default router), also work for other git host websites, e.g. generate `/src` for bitbucket.org.
 - `blame`: generate the `/blame` urls, also work for other git host websites, e.g. generate `/annotate` for bitbucket.org.
 
-By default `GitLink` will use the first detected remote (usually `origin`), but if you need to specify other remotes with `remote=xxx` arguments. For example `upstream`, please use:
+By default `GitLink` will use the first detected remote (`origin`), but if you need to specify other remotes with `remote=xxx` arguments. For example `upstream`, please use:
 
 - `GitLink (blame) remote=upstream`: copy upstream url to clipboard.
 - `GitLink! (blame) remote=upstream`: open upstream url in browser.

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ There're two **routers** provided:
 
 By default `GitLink` will use the first detected remote (`origin`), but if you need to specify other remotes with `remote=xxx` arguments. For example `upstream`, please use:
 
-- `GitLink (blame) remote=upstream`: copy upstream url to clipboard.
-- `GitLink! (blame) remote=upstream`: open upstream url in browser.
+- `GitLink remote=upstream`: copy upstream url to clipboard.
+- `GitLink! remote=upstream`: open upstream url in browser.
 
 <details>
 <summary><i>Click here to see recommended key mappings</i></summary>

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ The available variables are the same with the `lk` parameter passing to hook fun
 - `_A.HOST`: `github.com`, `gitlab.com`, `bitbucket.org`, etc.
 - `_A.USER`: `linrongbin16` (for this plugin), `neovim` (for [neovim](https://github.com/neovim/neovim)), etc.
 - `_A.REPO`: `gitlinker.nvim`, `neovim`, etc.
-  - **Note:** for easier writing, the `.git` suffix has been removed.
+  - **Note:** for easier writing, the `.git` suffix is been removed.
 - `_A.REV`: git commit, e.g. `dbf3922382576391fbe50b36c55066c1768b08b6`.
 - `_A.DEFAULT_BRANCH`: git default branch, `master`, `main`, etc, retrieved from `git rev-parse --abbrev-ref origin/HEAD`.
 - `_A.CURRENT_BRANCH`: git current branch, `feat-router-types`, etc, retrieved from `git rev-parse --abbrev-ref HEAD`.
@@ -435,7 +435,7 @@ protocol host            user      repo               file       rev            
 The difference is: the main repo doesn't have the `user` component, it's just `https://git.samba.org/?p=samba.git`. To support such case, `user` and `repo` components have a little bit different when facing the main repo:
 
 - `lk.user` (`_A.USER`): the value is `` (empty string).
-- `lk.repo` (`_A.REPO`): the value is `samba.git` (`_A.REPO` value is `samba`, suffix `.git` has been removed for easier writing url template).
+- `lk.repo` (`_A.REPO`): the value is `samba.git` (`_A.REPO` value is `samba`, the `.git` suffix is been removed for easier writing url template).
 
 ### More Router Types
 

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ Then test with `vusted ./test`.
 
 ## Contribute
 
-Please also open [issue](https://github.com/linrongbin16/gitlinker.nvim/issues)/[PR](https://github.com/linrongbin16/gitlinker.nvim/pulls) for anything about gitlinker.nvim.
+Please open [issue](https://github.com/linrongbin16/gitlinker.nvim/issues)/[PR](https://github.com/linrongbin16/gitlinker.nvim/pulls) for anything about gitlinker.nvim.
 
 Like gitlinker.nvim? Consider
 

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -571,6 +571,16 @@ local function setup(opts)
     range = true,
     bang = true,
     desc = Configs.command.desc,
+    complete = function()
+      local suggestions = {}
+      for router_type, _ in pairs(Configs._routers) do
+        table.insert(suggestions, router_type)
+      end
+      table.sort(suggestions, function(a, b)
+        return a < b
+      end)
+      return suggestions
+    end,
   })
 
   if type(Configs.mapping) == "table" then

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -119,14 +119,16 @@ local function _parse_remote_url(remote_url)
 end
 
 --- @alias gitlinker.Linker {remote_url:string,protocol:string,host:string,host_delimiter:string,user:string,repo:string?,rev:string,file:string,lstart:integer,lend:integer,file_changed:boolean,default_branch:string?,current_branch:string?}
+--- @param remote string?
 --- @return gitlinker.Linker?
-local function make_linker()
+local function make_linker(remote)
   local root = git.get_root()
   if not root then
     return nil
   end
 
-  local remote = git.get_branch_remote()
+  remote = (type(remote) == "string" and string.len(remote) > 0) and remote
+    or git.get_branch_remote()
   if not remote then
     return nil
   end

--- a/test.lua
+++ b/test.lua
@@ -1,2 +1,0 @@
-vim.api.nvim_set_hl( 0, "NvimGitLinkerHighlightTextObject", { link = "Constant" })
-

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,2 @@
+vim.api.nvim_set_hl( 0, "NvimGitLinkerHighlightTextObject", { link = "Constant" })
+


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Hosts

- [x] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [x] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [x] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
