### PR TITLE
fix: Update linker.lua to parse ssh:// URLs.

### DIFF
--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -16,7 +16,7 @@ local async = require("gitlinker.commons.async")
 local function _parse_remote_url(remote_url)
   local logger = logging.get("gitlinker") --[[@as commons.logging.Logger]]
 
-  local PROTOS = { "git@", "https://", "http://" }
+  local PROTOS = { "git@", "https://", "http://", "ssh://" }
   local INT32_MAX = 2 ^ 31 - 1
 
   local protocol = nil


### PR DESCRIPTION
At my company, we use GitHub with `ssh://` URLs in the form of:

`ssh://<someuser>@github.com/organization/repo.git`

gitlinker doesn't parse the `ssh` protocol:

```
Error executing luv callback:
...nvim/lazy/gitlinker.nvim/lua/gitlinker/commons/async.lua:80: The coroutine failed with this message:
.../share/nvim/lazy/gitlinker.nvim/lua/gitlinker/linker.lua:42: failed to parse remote url protocol:"ssh://<someuser>@github.com/organization/repo.git"
stack traceback:
	[C]: in function 'error'
	.../share/nvim/lazy/gitlinker.nvim/lua/gitlinker/linker.lua:42: in function '_parse_remote_url'
	.../share/nvim/lazy/gitlinker.nvim/lua/gitlinker/linker.lua:141: in function 'make_linker'
	.../.local/share/nvim/lazy/gitlinker.nvim/lua/gitlinker.lua:360: in function <.../.local/share/nvim/lazy/gitlinker.nvim/lua/gitlinker.lua:356>
stack traceback:
	[C]: in function 'error'
	...nvim/lazy/gitlinker.nvim/lua/gitlinker/commons/async.lua:80: in function 'cb'
	...nvim/lazy/gitlinker.nvim/lua/gitlinker/commons/async.lua:120: in function 'callback'
	...cal/share/nvim/lazy/gitlinker.nvim/lua/gitlinker/git.lua:61: in function 'on_exit'
	...ovim/HEAD-6635ec1/share/nvim/runtime/lua/vim/_system.lua:297: in function <...ovim/HEAD-6635ec1/share/nvim/runtime/lua/vim/_system.lua:267>
```

This change fixes that.

# Regression Test

## Platforms

- [ ] windows
- [X] macOS
- [ ] linux

## Hosts

- [X] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [X] Use `GitLink` to copy git link.
- [X] Use `GitLink!` to open git link in browser.
- [X] Use `GitLink blame` to copy the `/blame` git link.
- [X] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
