### PR TITLE
test(link): fix unit tests in sync mode

### DIFF
--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -353,7 +353,7 @@ local function _blame(lk)
 end
 
 --- @param opts {action:gitlinker.Action?,router:gitlinker.Router,lstart:integer,lend:integer,remote:string?}
-local link = function(opts)
+local _link = function(opts)
   local logger = logging.get("gitlinker") --[[@as commons.logging.Logger]]
   -- logger.debug("[link] merged opts: %s", vim.inspect(opts))
 
@@ -401,7 +401,7 @@ local link = function(opts)
 end
 
 --- @type fun(opts:{action:gitlinker.Action?,router:gitlinker.Router,lstart:integer,lend:integer,remote:string?}):string?
-local void_link = async.void(link)
+local link = async.void(_link)
 
 --- @param opts gitlinker.Options
 --- @return table<string, {list_routers:table,map_routers:table}>
@@ -544,7 +544,7 @@ local function setup(opts)
     local lend =
       math.max(r.lstart, r.lend, command_opts.line1, command_opts.line2)
     local parsed = _parse_args(args)
-    void_link({
+    link({
       action = command_opts.bang and require("gitlinker.actions").system
         or require("gitlinker.actions").clipboard,
       router = function(lk)


### PR DESCRIPTION
# For New Use Cases

1. What's the output of `git config --get remote.origin.url`?

   It's ...

2. what's the expect git host url you want to generate?

   It's ...

3. how do you configure this plugin?

   It's ...

# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
