### PR TITLE
feat(router): support 'username:password@host' matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,15 @@ require('gitlinker').setup({
 })
 ```
 
+> [!IMPORTANT]
+>
+> The `router` option in [Configuration](#configuration) is mapping from git `host` (such as `github.com`, `gitlab.com`) to the expected git url you want to generate.
+>
+> It also support `username` and `password`, for example:
+>
+> - `git@github.com`
+> - `myname:mypass@githost.xyz`
+
 ### Highlighting
 
 To create your own highlighting, please use below config before setup this plugin:
@@ -291,6 +300,8 @@ hi link NvimGitLinkerHighlightTextObject Constant
 ```
 
 > Also see [Highlight Group](#highlight-group).
+
+### Router Mapping
 
 ### Self-host Git Hosts
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ require('gitlinker').setup({
 >
 > The `router` option in [Configuration](#configuration) is mapping from git `host` (such as `github.com`, `gitlab.com`) to the expected git url you want to generate.
 >
-> It also support `username` and `password`, for example:
+> It also support mapping `username` and `password`, for example:
 >
 > - `git@github.com`
 > - `myname:mypass@githost.xyz`
@@ -358,37 +358,36 @@ To fully customize url generation, please refer to the implementation of [router
   - The `22` in `https://github.com:22/linrongbin16/gitlinker.nvim`.
   - The `123456` in `https://127.0.0.1:123456/linrongbin16/gitlinker.nvim`.
 - `path`: All the left parts after `host` (and optional `port`). For example:
-  - `/linrongbin16/gitlinker.nvim.git` in `https://github.com/linrongbin16/gitlinker.nvim.git`.
-  - `linrongbin16/gitlinker.nvim.git` in `git@github.com:linrongbin16/gitlinker.nvim.git`.
+  - The `/linrongbin16/gitlinker.nvim.git` in `https://github.com/linrongbin16/gitlinker.nvim.git`.
+  - The `linrongbin16/gitlinker.nvim.git` in `git@github.com:linrongbin16/gitlinker.nvim.git`.
 - `rev`: Git commit. For example:
-  - The `a009dacda96756a8c418ff5fa689999b148639f6` in `https://github.com/linrongbin16/gitlinker.nvim/blob/a009dacda96756a8c418ff5fa689999b148639f6/lua/gitlinker/git.lua?plain=1#L3`.
+  - The `a009dacda96756a8c418ff5fa689999b148639f6` in `https://github.com/linrongbin16/gitlinker.nvim/blob/a009dacda96756a8c418ff5fa689999b148639f6/lua/gitlinker/git.lua`.
 - `file`: Relative file path. For example:
-  - `lua/gitlinker/routers.lua` in `https://github.com/linrongbin16/gitlinker.nvim/blob/master/lua/gitlinker/routers.lua`.
+  - The `lua/gitlinker/routers.lua` in `https://github.com/linrongbin16/gitlinker.nvim/blob/master/lua/gitlinker/routers.lua`.
 - `lstart`/`lend`: Start/end line numbers. For example:
-  - `3`/`13` in `https://github.com/linrongbin16/gitlinker.nvim/blob/master/lua/gitlinker/routers.lua#L3-L13`.
+  - The `3`/`13` in `https://github.com/linrongbin16/gitlinker.nvim/blob/master/lua/gitlinker/routers.lua#L3-L13`.
 
 There're also 2 sugar components derived from `path`:
 
 - `repo`: The last part after the last slash (`/`) in `path`, with around slashes been removed. For example:
-  - `gitlinker.nvim.git` in `https://github.com/linrongbin16/gitlinker.nvim`.
-  - `neovim.git` in `https://github.com/neovim/neovim.git`.
+  - The `gitlinker.nvim.git` in `https://github.com/linrongbin16/gitlinker.nvim`.
+  - The `neovim.git` in `https://github.com/neovim/neovim.git`.
 - `org`: (Optional) all the other parts before `repo` in `path`, with around slashes been removed. For example:
-  - `linrongbin16` in `https://github.com/linrongbin16/gitlinker.nvim.git`.
-  - `path/to/the` in `https://github.com/path/to/the/repo.git`.
+  - The `linrongbin16` in `https://github.com/linrongbin16/gitlinker.nvim.git`.
+  - The `path/to/the` in `https://github.com/path/to/the/repo.git`.
+  - Empty string in `ssh://git@host.xyz/repo.git`.
 
 > [!NOTE]
 >
 > The `org` component can be empty when the `path` only contains 1 slash (`/`), for example:
->
-> - `ssh://git@host.xyz/repo.git`.
 
 There're also 2 branch components:
 
 - `default_branch`: Default branch retrieved from `git rev-parse --abbrev-ref origin/HEAD`. For example:
-  - `master` in `https://github.com/ruifm/gitlinker.nvim/blob/master/lua/gitlinker/routers.lua#L37-L156`.
-  - `main` in `https://github.com/linrongbin16/commons.nvim/blob/main/lua/commons/uv.lua`.
+  - The `master` in `https://github.com/ruifm/gitlinker.nvim/blob/master/README.md`.
+  - The `main` in `https://github.com/linrongbin16/commons.nvim/blob/main/README.md`.
 - `current_branch`: Current branch retrieved from `git rev-parse --abbrev-ref HEAD`. For example:
-  - `feat-router-types`
+  - The `feat-router-types`.
 
 For example you can customize the line numbers in form `?&line=1&lines-count=2` like this:
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ require('gitlinker').setup({
 >
 > - `git@github.com`
 > - `myname:mypass@githost.xyz`
+>
+> Please see [Fully Customize Urls](#fully-customize-urls) for more details.
 
 ### Highlighting
 

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -267,6 +267,24 @@ local function _router(router_type, lk)
 
   local logger = logging.get("gitlinker") --[[@as commons.logging.Logger]]
 
+  local match_list = {}
+  -- host: github.com
+  table.insert(match_list, lk.host)
+  -- username@host: git@github.com
+  -- username:password@host: myname:mypass@github.com
+  if strings.not_empty(lk.username) then
+    if strings.not_empty(lk.password) then
+      table.insert(
+        match_list,
+        string.format("%s:%s@%s", lk.username, lk.password, lk.host)
+      )
+    else
+      table.insert(match_list, string.format("%s@%s", lk.username, lk.host))
+    end
+  end
+  -- full remote url from `git remote get-url origin`: https://github.com/linrongbin16/gitlinker.nvim.git
+  table.insert(match_list, lk.remote_url)
+
   for i, tuple in ipairs(Configs._routers[router_type].list_routers) do
     if type(i) == "number" and type(tuple) == "table" and #tuple == 2 then
       local pattern = tuple[1]
@@ -280,16 +298,15 @@ local function _router(router_type, lk)
       --   vim.inspect(string.match(lk.remote_url, pattern)),
       --   vim.inspect(lk.remote_url)
       -- )
-      if
-        string.match(lk.host, pattern)
-        or string.match(lk.remote_url, pattern)
-      then
-        -- logger:debug(
-        --   "|_router| match-1 router:%s with pattern:%s",
-        --   vim.inspect(route),
-        --   vim.inspect(pattern)
-        -- )
-        return _worker(lk, pattern, route)
+      for j, target in ipairs(match_list) do
+        if string.match(target, pattern) then
+          -- logger:debug(
+          --   "|_router| match-1 router:%s with pattern:%s",
+          --   vim.inspect(route),
+          --   vim.inspect(pattern)
+          -- )
+          return _worker(lk, pattern, route)
+        end
       end
     end
   end
@@ -305,16 +322,15 @@ local function _router(router_type, lk)
       --   vim.inspect(lk.host),
       --   vim.inspect(lk.remote_url)
       -- )
-      if
-        string.match(lk.host, pattern)
-        or string.match(lk.remote_url, pattern)
-      then
-        -- logger:debug(
-        --   "|_router| match-2 router:%s with pattern:%s",
-        --   vim.inspect(route),
-        --   vim.inspect(pattern)
-        -- )
-        return _worker(lk, pattern, route)
+      for j, target in ipairs(match_list) do
+        if string.match(target, pattern) then
+          -- logger:debug(
+          --   "|_router| match-1 router:%s with pattern:%s",
+          --   vim.inspect(route),
+          --   vim.inspect(pattern)
+          -- )
+          return _worker(lk, pattern, route)
+        end
       end
     end
   end


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Hosts

- [x] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [x] Use `GitLink` to copy git link.
- [x] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
