### PR TITLE
feat(router): add 'default_branch' router type

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://gitlab.com/linrongbin16/test/-/blame/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L4-8
+      -- example: https://gitlab.com/linrongbin16/test/blame/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L4-8
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/blame/"
@@ -268,10 +268,10 @@ require('gitlinker').setup({
         .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://gitlab.com/linrongbin16/test/-/blob/main/test.lua#L3-L4
+      -- example: https://gitlab.com/linrongbin16/test/blob/main/test.lua#L3-L4
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
-        .. "{_A.REPO}/-/blob/"
+        .. "{_A.REPO}/blob/"
         .. "{_A.DEFAULT_BRANCH}/"
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ require('gitlinker').setup({
   -- user command
   command = {
     name = "GitLink",
-    desc = "Generate git link",
+    desc = "Generate git permanent link",
   },
 
   -- router bindings

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://gitlab.com/linrongbin16/gitlinker.nvim/blob/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://gitlab.com/linrongbin16/test/blob/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L3-L5
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/blob/"
@@ -199,7 +199,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/src/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/src/dbf3922382576391fbe50b36c55066c1768b08b6/.gitignore#lines-9:14
       ["^bitbucket%.org"] = "https://bitbucket.org/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/src/"
@@ -207,7 +207,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
-      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/src/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L5-L6
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/src/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L4-L7
       ["^codeberg%.org"] = "https://codeberg.org/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/src/commit/"
@@ -217,7 +217,7 @@ require('gitlinker').setup({
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
       -- example:
       -- main repo: https://git.samba.org/?p=samba.git;a=blob;f=wscript;hb=83e8971c0f1c1db8c3574f83107190ac1ac23db0#l6
-      -- dev repo: https://git.samba.org/?p=bbaumbach/samba.git;a=blob;f=wscript;hb=8de348e9d025d336a7985a9025fe08b7096c0394#l7
+      -- user repo: https://git.samba.org/?p=bbaumbach/samba.git;a=blob;f=wscript;hb=8de348e9d025d336a7985a9025fe08b7096c0394#l7
       ["^git%.samba%.org"] = "https://git.samba.org/?p="
         .. "{string.len(_A.ORG) > 0 and (_A.ORG .. '/') or ''}" -- 'p=samba.git;' or 'p=bbaumbach/samba.git;'
         .. "{_A.REPO .. '.git'};a=blob;"
@@ -226,7 +226,7 @@ require('gitlinker').setup({
         .. "#l{_A.LSTART}",
     },
     blame = {
-      -- example: https://github.com/linrongbin16/gitlinker.nvim/blame/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://github.com/linrongbin16/gitlinker.nvim/blame/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L7
       ["^github%.com"] = "https://github.com/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/blame/"
@@ -234,7 +234,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://gitlab.com/linrongbin16/gitlinker.nvim/blame/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://gitlab.com/linrongbin16/test/-/blame/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L4-8
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/blame/"
@@ -242,7 +242,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/annotate/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#lines-3:4
+      -- example: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/annotate/dbf3922382576391fbe50b36c55066c1768b08b6/.gitignore#lines-9:14
       ["^bitbucket%.org"] = "https://bitbucket.org/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/annotate/"
@@ -250,7 +250,7 @@ require('gitlinker').setup({
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
-      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L5-L6
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L4-L7
       ["^codeberg%.org"] = "https://codeberg.org/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/blame/commit/"
@@ -258,6 +258,48 @@ require('gitlinker').setup({
         .. "{_A.FILE}?display=source" -- '?display=source'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+    },
+    default_branch = {
+      -- example: https://github.com/linrongbin16/gitlinker.nvim/blob/master/lua/gitlinker.lua#L3-L4
+      ["^github%.com"] = "https://github.com/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/blob/"
+        .. "{_A.DEFAULT_BRANCH}/"
+        .. "{_A.FILE}?plain=1" -- '?plain=1'
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+      -- example: https://gitlab.com/linrongbin16/test/-/blob/main/test.lua#L3-L4
+      ["^gitlab%.com"] = "https://gitlab.com/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/-/blob/"
+        .. "{_A.DEFAULT_BRANCH}/"
+        .. "{_A.FILE}"
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+      -- example: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/src/master/.gitignore#lines-9:14
+      ["^bitbucket%.org"] = "https://bitbucket.org/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/src/"
+        .. "{_A.DEFAULT_BRANCH}/"
+        .. "{_A.FILE}"
+        .. "#lines-{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/src/branch/main/LICENSE#L4-L6
+      ["^codeberg%.org"] = "https://codeberg.org/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/src/branch/"
+        .. "{_A.DEFAULT_BRANCH}/"
+        .. "{_A.FILE}?display=source" -- '?display=source'
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+      -- example:
+      -- main repo: https://git.samba.org/?p=samba.git;a=blob;f=wscript#l6
+      -- user repo: https://git.samba.org/?p=bbaumbach/samba.git;a=blob;f=wscript#l7
+      ["^git%.samba%.org"] = "https://git.samba.org/?p="
+        .. "{string.len(_A.ORG) > 0 and (_A.ORG .. '/') or ''}" -- 'p=samba.git;' or 'p=bbaumbach/samba.git;'
+        .. "{_A.REPO .. '.git'};a=blob;"
+        .. "f={_A.FILE}"
+        .. "#l{_A.LSTART}",
     },
   },
 

--- a/README.md
+++ b/README.md
@@ -174,11 +174,8 @@ require('gitlinker').setup({
 
   -- user command
   command = {
-    -- to copy link to clipboard, use: 'GitLink'
-    -- to open link in browser, use bang: 'GitLink!'
-    -- to use blame router, use: 'GitLink blame' and 'GitLink! blame'
     name = "GitLink",
-    desc = "Generate git permanent link",
+    desc = "Generate git link",
   },
 
   -- router bindings

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <a href="https://app.codecov.io/github/linrongbin16/gitlinker.nvim"><img alt="codecov" src="https://img.shields.io/codecov/c/github/linrongbin16/gitlinker.nvim/main?label=codecov" /></a>
 </p>
 
-> Maintained fork of [ruifm's gitlinker](https://github.com/ruifm/gitlinker.nvim), refactored with bug fixes, ssh host alias, `/blame` url support and other improvements.
+> Maintained fork of [ruifm's gitlinker](https://github.com/ruifm/gitlinker.nvim), refactored with bug fixes, ssh host alias, blame support and other improvements.
 
 A lua plugin for [Neovim](https://github.com/neovim/neovim) to generate sharable file permalinks (with line ranges) for git host websites. Inspired by [tpope/vim-fugitive](https://github.com/tpope/vim-fugitive)'s `:GBrowse`.
 
@@ -51,7 +51,7 @@ PRs are welcomed for other git host websites!
    - Windows (+wsl2) support.
    - Respect ssh host alias.
    - Add `?plain=1` for markdown files.
-   - Support `/blame` (by default is `/blob`).
+   - Support blame url.
    - Full [git protocols](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols) support.
 3. Improvements:
    - Use stderr from git command as error message.
@@ -103,22 +103,23 @@ return require('pckr').add(
 
 You could use below command:
 
-- `GitLink`: copy the `/blob` url to clipboard.
-- `GitLink!`: open the `/blob` url in browser.
-- `GitLink blame`: copy the `/blame` url to clipboard.
-- `GitLink! blame`: open the `/blame` url in browser.
+- `GitLink(!)`: copy the `/blob` url to clipboard (use `!` to open in browser).
+- `GitLink(!) blame`: copy the `blame` url to clipboard (use `!` to open in browser).
+- `GitLink(!) default_branch`: copy the `main`/`master` url to clipboard (use `!` to open in browser).
 
-There're **2 routers** provided:
+There're **3 routers** provided:
 
 - `browse`: generate the `/blob` url (default).
 - `blame`: generate the `/blame` url.
+- `default_branch`: generate the `/main`/`master` url.
 
 > [!NOTE]
 >
-> They also work for other git host websites, for example for bitbucket.org.
+> Routers can work for any git hosts, for example for bitbucket.org.
 >
 > - `browse`: generate the `/src` url (default).
 > - `blame`: generate the `/annotate` url.
+> - `default_branch`: generate the `/main` or `/master` url based on actual project.
 
 By default `GitLink` will use the first detected remote (`origin`), but if you need to specify other remotes, please use `remote=xxx` arguments. For example:
 

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -87,7 +87,7 @@ local Defaults = {
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/annotate/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#lines-3:4
+      -- example: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/annotate/dbf3922382576391fbe50b36c55066c1768b08b6/.gitignore#lines-9:14
       ["^bitbucket%.org"] = "https://bitbucket.org/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/annotate/"
@@ -95,7 +95,7 @@ local Defaults = {
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
-      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L5-L6
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/blame/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L4-L7
       ["^codeberg%.org"] = "https://codeberg.org/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/blame/commit/"

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -36,10 +36,10 @@ local Defaults = {
         .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://gitlab.com/linrongbin16/test/-/blob/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L3-L5
+      -- example: https://gitlab.com/linrongbin16/test/blob/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L3-L5
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
-        .. "{_A.REPO}/-/blob/"
+        .. "{_A.REPO}/blob/"
         .. "{_A.REV}/"
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
@@ -82,7 +82,7 @@ local Defaults = {
       -- example: https://gitlab.com/linrongbin16/test/-/blame/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L4-8
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
-        .. "{_A.REPO}/-/blame/"
+        .. "{_A.REPO}/blame/"
         .. "{_A.REV}/"
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -36,7 +36,7 @@ local Defaults = {
         .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://gitlab.com/linrongbin16/gitlinker.nvim/blob/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://gitlab.com/linrongbin16/test/-/blob/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L3-L5
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/-/blob/"
@@ -44,7 +44,7 @@ local Defaults = {
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://bitbucket.org/linrongbin16/gitlinker.nvim/src/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/src/dbf3922382576391fbe50b36c55066c1768b08b6/.gitignore#lines-9:14
       ["^bitbucket%.org"] = "https://bitbucket.org/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/src/"

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -139,7 +139,7 @@ local Defaults = {
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
       -- example:
       -- main repo: https://git.samba.org/?p=samba.git;a=blob;f=wscript#l6
-      -- dev repo: https://git.samba.org/?p=bbaumbach/samba.git;a=blob;f=wscript#l7
+      -- user repo: https://git.samba.org/?p=bbaumbach/samba.git;a=blob;f=wscript#l7
       ["^git%.samba%.org"] = "https://git.samba.org/?p="
         .. "{string.len(_A.ORG) > 0 and (_A.ORG .. '/') or ''}" -- 'p=samba.git;' or 'p=bbaumbach/samba.git;'
         .. "{_A.REPO .. '.git'};a=blob;"

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -52,7 +52,7 @@ local Defaults = {
         .. "{_A.FILE}"
         .. "#lines-{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
-      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/src/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L5-L6
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/src/commit/a570f22ff833447ee0c58268b3bae4f7197a8ad8/LICENSE#L4-L7
       ["^codeberg%.org"] = "https://codeberg.org/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/src/commit/"
@@ -62,7 +62,7 @@ local Defaults = {
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
       -- example:
       -- main repo: https://git.samba.org/?p=samba.git;a=blob;f=wscript;hb=83e8971c0f1c1db8c3574f83107190ac1ac23db0#l6
-      -- dev repo: https://git.samba.org/?p=bbaumbach/samba.git;a=blob;f=wscript;hb=8de348e9d025d336a7985a9025fe08b7096c0394#l7
+      -- user repo: https://git.samba.org/?p=bbaumbach/samba.git;a=blob;f=wscript;hb=8de348e9d025d336a7985a9025fe08b7096c0394#l7
       ["^git%.samba%.org"] = "https://git.samba.org/?p="
         .. "{string.len(_A.ORG) > 0 and (_A.ORG .. '/') or ''}" -- 'p=samba.git;' or 'p=bbaumbach/samba.git;'
         .. "{_A.REPO .. '.git'};a=blob;"
@@ -71,7 +71,7 @@ local Defaults = {
         .. "#l{_A.LSTART}",
     },
     blame = {
-      -- example: https://github.com/linrongbin16/gitlinker.nvim/blame/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://github.com/linrongbin16/gitlinker.nvim/blame/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L7
       ["^github%.com"] = "https://github.com/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/blame/"

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -79,7 +79,7 @@ local Defaults = {
         .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://gitlab.com/linrongbin16/gitlinker.nvim/blame/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
+      -- example: https://gitlab.com/linrongbin16/test/-/blame/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L4-8
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/-/blame/"

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -39,7 +39,7 @@ local Defaults = {
       -- example: https://gitlab.com/linrongbin16/gitlinker.nvim/blob/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
-        .. "{_A.REPO}/blob/"
+        .. "{_A.REPO}/-/blob/"
         .. "{_A.REV}/"
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
@@ -82,7 +82,7 @@ local Defaults = {
       -- example: https://gitlab.com/linrongbin16/gitlinker.nvim/blame/9679445c7a24783d27063cd65f525f02def5f128/lua/gitlinker.lua#L3-L4
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
-        .. "{_A.REPO}/blame/"
+        .. "{_A.REPO}/-/blame/"
         .. "{_A.REV}/"
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"
@@ -103,6 +103,48 @@ local Defaults = {
         .. "{_A.FILE}?display=source" -- '?display=source'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+    },
+    default_branch = {
+      -- example: https://github.com/linrongbin16/gitlinker.nvim/blob/master/lua/gitlinker.lua#L3-L4
+      ["^github%.com"] = "https://github.com/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/blob/"
+        .. "{_A.DEFAULT_BRANCH}/"
+        .. "{_A.FILE}?plain=1" -- '?plain=1'
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+      -- example: https://gitlab.com/linrongbin16/test/-/blob/main/test.lua#L3-L4
+      ["^gitlab%.com"] = "https://gitlab.com/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/-/blob/"
+        .. "{_A.DEFAULT_BRANCH}/"
+        .. "{_A.FILE}"
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+      -- example: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/src/master/.gitignore#lines-9:14
+      ["^bitbucket%.org"] = "https://bitbucket.org/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/src/"
+        .. "{_A.DEFAULT_BRANCH}/"
+        .. "{_A.FILE}"
+        .. "#lines-{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/src/branch/main/LICENSE#L4-L6
+      ["^codeberg%.org"] = "https://codeberg.org/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/src/branch/"
+        .. "{_A.DEFAULT_BRANCH}/"
+        .. "{_A.FILE}?display=source" -- '?display=source'
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+      -- example:
+      -- main repo: https://git.samba.org/?p=samba.git;a=blob;f=wscript#l6
+      -- dev repo: https://git.samba.org/?p=bbaumbach/samba.git;a=blob;f=wscript#l7
+      ["^git%.samba%.org"] = "https://git.samba.org/?p="
+        .. "{string.len(_A.ORG) > 0 and (_A.ORG .. '/') or ''}" -- 'p=samba.git;' or 'p=bbaumbach/samba.git;'
+        .. "{_A.REPO .. '.git'};a=blob;"
+        .. "f={_A.FILE}"
+        .. "#l{_A.LSTART}",
     },
   },
 

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -17,10 +17,6 @@ local Defaults = {
 
   -- user command
   command = {
-    -- to copy link to clipboard, use: 'GitLink'
-    -- to open link in browser, use bang: 'GitLink!'
-    -- to use blame router, use: 'GitLink blame'
-    -- to use browse router, use: 'GitLink browse' (which is the default router)
     name = "GitLink",
     desc = "Generate git permanent link",
   },

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -79,7 +79,7 @@ local Defaults = {
         .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://gitlab.com/linrongbin16/test/-/blame/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L4-8
+      -- example: https://gitlab.com/linrongbin16/test/blame/e1c498a4bae9af6e61a2f37e7ae622b2cc629319/test.lua#L4-8
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
         .. "{_A.REPO}/blame/"
@@ -113,10 +113,10 @@ local Defaults = {
         .. "{_A.FILE}?plain=1" -- '?plain=1'
         .. "#L{_A.LSTART}"
         .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
-      -- example: https://gitlab.com/linrongbin16/test/-/blob/main/test.lua#L3-L4
+      -- example: https://gitlab.com/linrongbin16/test/blob/main/test.lua#L3-L4
       ["^gitlab%.com"] = "https://gitlab.com/"
         .. "{_A.ORG}/"
-        .. "{_A.REPO}/-/blob/"
+        .. "{_A.REPO}/blob/"
         .. "{_A.DEFAULT_BRANCH}/"
         .. "{_A.FILE}"
         .. "#L{_A.LSTART}"


### PR DESCRIPTION
Resolve #151 .

# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Hosts

- [x] Test on [github.com](https://github.com).
- [x] Test on [gitlab.com](https://gitlab.com).
- [x] Test on [bitbucket.org](https://bitbucket.org).
- [x] Test on [codeberg.org](https://codeberg.org).
- [x] Test on [git.samba.org](https://git.samba.org).

## Functions

- [x] Use `GitLink` to copy git link.
- [x] Use `GitLink!` to open git link in browser.
- [x] Use `GitLink blame` to copy the `/blame` git link.
- [x] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
