### PR TITLE
docs(usage): wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ return require('pckr').add(
 You could use below command:
 
 - `GitLink(!)`: copy the `/blob` url to clipboard (use `!` to open in browser).
-- `GitLink(!) blame`: copy the `blame` url to clipboard (use `!` to open in browser).
-- `GitLink(!) default_branch`: copy the `main`/`master` url to clipboard (use `!` to open in browser).
+- `GitLink(!) blame`: copy the `/blame` url to clipboard (use `!` to open in browser).
+- `GitLink(!) default_branch`: copy the `/main` or `/master` url to clipboard (use `!` to open in browser).
 
 There're **3 routers** provided:
 
 - `browse`: generate the `/blob` url (default).
 - `blame`: generate the `/blame` url.
-- `default_branch`: generate the `/main`/`master` url.
+- `default_branch`: generate the `/main` or `/master` url.
 
 > [!NOTE]
 >


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
