### PR TITLE
docs(routers): fix 'gitlinker.routers' module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ require("gitlinker").setup({
 })
 ```
 
-There are some pre-defined lua apis in `gitlinker.router` that you can use:
+There are some pre-defined lua apis in `gitlinker.routers` that you can use:
 
 - `github_browse`/`github_blame`: for github.com.
 - `gitlab_browse`/`gitlab_blame`: for gitlab.com.
@@ -339,10 +339,10 @@ For example if you need to bind a github enterprise domain, you can use:
 require('gitlinker').setup({
   router = {
     browse = {
-      ["^github%.your%.host"] = require('gitlinker.router').github_browse,
+      ["^github%.your%.host"] = require('gitlinker.routers').github_browse,
     },
     blame = {
-      ["^github%.your%.host"] = require('gitlinker.router').github_blame,
+      ["^github%.your%.host"] = require('gitlinker.routers').github_blame,
     },
   }
 })


### PR DESCRIPTION
Fix #210.

# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink` to copy git link.
- [ ] Use `GitLink!` to open git link in browser.
- [ ] Use `GitLink blame` to copy the `/blame` git link.
- [ ] Use `GitLink! blame` to open the `/blame` git link in browser.
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
