### PR TITLE
feat(router): add 'current_branch' router

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@
 - [ ] Use `GitLink(!)` to copy git link (or open in browser).
 - [ ] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
 - [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
+- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
 - [ ] Copy git link in a symlink directory of git repo.
 - [ ] Copy git link in an un-pushed git branch, and receive an expected error.
 - [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.

--- a/README.md
+++ b/README.md
@@ -111,12 +111,14 @@ You can use the user command `GitLink` to generate git permlink:
 - `GitLink(!)`: copy the `/blob` url to clipboard (use `!` to open in browser).
 - `GitLink(!) blame`: copy the `/blame` url to clipboard (use `!` to open in browser).
 - `GitLink(!) default_branch`: copy the `/main` or `/master` url to clipboard (use `!` to open in browser).
+- `GitLink(!) current_branch`: copy the current branch url to clipboard (use `!` to open in browser).
 
 There're several **router types**:
 
 - `browse`: generate the `/blob` url (default).
 - `blame`: generate the `/blame` url.
 - `default_branch`: generate the `/main` or `/master` url.
+- `current_branch`: generate the current branch url.
 
 > [!NOTE]
 >
@@ -124,7 +126,8 @@ There're several **router types**:
 >
 > - `browse` generate the `/src` url (default): https://bitbucket.org/gitlinkernvim/gitlinker.nvim/src/dbf3922382576391fbe50b36c55066c1768b08b6/.gitignore#lines-9:14.
 > - `blame` generate the `/annotate` url: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/annotate/dbf3922382576391fbe50b36c55066c1768b08b6/.gitignore#lines-9:14.
-> - `default_branch` generate the `/main` or `/master` url based on actual project: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/src/master/.gitignore#lines-9:14.
+> - `default_branch` generate the `/main` or `/master` url: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/src/master/.gitignore#lines-9:14.
+> - `current_branch` generate the current branch url: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/src/master/.gitignore#lines-9:14.
 
 There're several arguments:
 
@@ -161,6 +164,7 @@ require("gitlinker").link(opts)
     - `browse`
     - `blame`
     - `default_branch`
+    - `current_branch`
 
   - `router`: Which router implementation should this API use. By default is `nil`, it uses the configured router implementations while this plugin is been setup (see [Configuration](#configuration)). You can **_dynamically_** overwrite the generate behavior by pass a router in this field.
 
@@ -278,6 +282,19 @@ vim.keymap.set(
   "<cmd>GitLink! default_branch<cr>",
   { silent = true, noremap = true, desc = "Open default branch link in browser" }
 )
+-- default branch
+vim.keymap.set(
+  {"n", 'v'},
+  "<leader>gc",
+  "<cmd>GitLink current_branch<cr>",
+  { silent = true, noremap = true, desc = "Copy current branch link to clipboard" }
+)
+vim.keymap.set(
+  {"n", 'v'},
+  "<leader>gD",
+  "<cmd>GitLink! current_branch<cr>",
+  { silent = true, noremap = true, desc = "Open current branch link in browser" }
+)
 ```
 
 </details>
@@ -343,6 +360,26 @@ vim.keymap.set(
     })
   end,
   { silent = true, noremap = true, desc = "GitLink! default_branch" }
+)
+-- default branch
+vim.keymap.set(
+  {"n", 'v'},
+  "<leader>gc",
+  function()
+    require("gitlinker").link({ router_type = "current_branch" })
+  end,
+  { silent = true, noremap = true, desc = "GitLink current_branch" }
+)
+vim.keymap.set(
+  {"n", 'v'},
+  "<leader>gC",
+  function()
+    require("gitlinker").link({
+      router_type = "current_branch",
+      action = require("gitlinker.actions").system,
+    })
+  end,
+  { silent = true, noremap = true, desc = "GitLink! current_branch" }
 )
 ```
 

--- a/lua/gitlinker/configs.lua
+++ b/lua/gitlinker/configs.lua
@@ -134,6 +134,48 @@ local Defaults = {
         .. "f={_A.FILE}"
         .. "#l{_A.LSTART}",
     },
+    current_branch = {
+      -- example: https://github.com/linrongbin16/gitlinker.nvim/blob/master/lua/gitlinker.lua#L3-L4
+      ["^github%.com"] = "https://github.com/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/blob/"
+        .. "{_A.CURRENT_BRANCH}/"
+        .. "{_A.FILE}?plain=1" -- '?plain=1'
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+      -- example: https://gitlab.com/linrongbin16/test/blob/main/test.lua#L3-L4
+      ["^gitlab%.com"] = "https://gitlab.com/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/blob/"
+        .. "{_A.CURRENT_BRANCH}/"
+        .. "{_A.FILE}"
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+      -- example: https://bitbucket.org/gitlinkernvim/gitlinker.nvim/src/master/.gitignore#lines-9:14
+      ["^bitbucket%.org"] = "https://bitbucket.org/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/src/"
+        .. "{_A.CURRENT_BRANCH}/"
+        .. "{_A.FILE}"
+        .. "#lines-{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and (':' .. _A.LEND) or '')}",
+      -- example: https://codeberg.org/linrongbin16/gitlinker.nvim/src/branch/main/LICENSE#L4-L6
+      ["^codeberg%.org"] = "https://codeberg.org/"
+        .. "{_A.ORG}/"
+        .. "{_A.REPO}/src/branch/"
+        .. "{_A.CURRENT_BRANCH}/"
+        .. "{_A.FILE}?display=source" -- '?display=source'
+        .. "#L{_A.LSTART}"
+        .. "{(_A.LEND > _A.LSTART and ('-L' .. _A.LEND) or '')}",
+      -- example:
+      -- main repo: https://git.samba.org/?p=samba.git;a=blob;f=wscript#l6
+      -- user repo: https://git.samba.org/?p=bbaumbach/samba.git;a=blob;f=wscript#l7
+      ["^git%.samba%.org"] = "https://git.samba.org/?p="
+        .. "{string.len(_A.ORG) > 0 and (_A.ORG .. '/') or ''}" -- 'p=samba.git;' or 'p=bbaumbach/samba.git;'
+        .. "{_A.REPO .. '.git'};a=blob;"
+        .. "f={_A.FILE}"
+        .. "#l{_A.LSTART}",
+    },
   },
 
   -- enable debug


### PR DESCRIPTION
# Regression Test

## Platforms

- [x] windows
- [ ] macOS
- [ ] linux

## Hosts

- [x] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [x] Use `GitLink(!)` to copy git link (or open in browser).
- [ ] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [x] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
