### PR TITLE
perf(actions): migrate 'jobstart' to 'spawn'

### DIFF
--- a/lua/gitlinker/actions.lua
+++ b/lua/gitlinker/actions.lua
@@ -1,3 +1,5 @@
+local spawn = require("gitlinker.commons.spawn")
+
 --- @alias gitlinker.Action fun(url:string):any
 
 -- copy url to clipboard
@@ -10,17 +12,19 @@ end
 -- see: https://github.com/axieax/urlview.nvim/blob/b183133fd25caa6dd98b415e0f62e51e061cd522/lua/urlview/actions.lua#L38
 --- @param url string
 local function system(url)
-  local job
+  local opts = {
+    text = true,
+  }
+  local on_exit = function(completed) end
   if vim.fn.has("mac") > 0 then
-    job = vim.fn.jobstart({ "open", url })
+    spawn.system({ "open", url }, opts, on_exit)
   elseif vim.fn.has("win32") > 0 or vim.fn.has("win64") > 0 then
-    job = vim.fn.jobstart({ "cmd", "/C", "start", url })
+    spawn.system({ "cmd", "/C", "start", url }, opts, on_exit)
   elseif vim.fn.executable("wslview") > 0 then
-    job = vim.fn.jobstart({ "wslview", url })
+    spawn.system({ "wslview", url }, opts, on_exit)
   else
-    job = vim.fn.jobstart({ "xdg-open", url })
+    spawn.system({ "xdg-open", url }, opts, on_exit)
   end
-  -- vim.fn.jobwait({ job })
 end
 
 local M = {

--- a/spec/gitlinker/actions_spec.lua
+++ b/spec/gitlinker/actions_spec.lua
@@ -1,0 +1,25 @@
+local cwd = vim.fn.getcwd()
+
+describe("gitlinker.actions", function()
+  local assert_eq = assert.is_equal
+  local assert_true = assert.is_true
+  local assert_false = assert.is_false
+
+  before_each(function()
+    vim.api.nvim_command("cd " .. cwd)
+  end)
+
+  local actions = require("gitlinker.actions")
+  require("gitlinker").setup()
+
+  describe("[highlight]", function()
+    local URL =
+      "https://github.com/axieax/urlview.nvim/blob/b183133fd25caa6dd98b415e0f62e51e061cd522/lua/urlview/actions.lua#L38"
+    it("copy to clipboard", function()
+      actions.clipboard(URL)
+    end)
+    it("open in browser", function()
+      actions.system(URL)
+    end)
+  end)
+end)

--- a/spec/gitlinker/configs_spec.lua
+++ b/spec/gitlinker/configs_spec.lua
@@ -1,6 +1,6 @@
 local cwd = vim.fn.getcwd()
 
-describe("gitlinker", function()
+describe("gitlinker.configs", function()
   local assert_eq = assert.is_equal
   local assert_true = assert.is_true
   local assert_false = assert.is_false

--- a/spec/gitlinker/git_spec.lua
+++ b/spec/gitlinker/git_spec.lua
@@ -1,6 +1,6 @@
 local cwd = vim.fn.getcwd()
 
-describe("git", function()
+describe("gitlinker.git", function()
   local assert_eq = assert.is_equal
   local assert_true = assert.is_true
   local assert_false = assert.is_false

--- a/spec/gitlinker/highlight_spec.lua
+++ b/spec/gitlinker/highlight_spec.lua
@@ -1,6 +1,6 @@
 local cwd = vim.fn.getcwd()
 
-describe("highlight", function()
+describe("gitlinker.highlight", function()
   local assert_eq = assert.is_equal
   local assert_true = assert.is_true
   local assert_false = assert.is_false

--- a/spec/gitlinker/linker_spec.lua
+++ b/spec/gitlinker/linker_spec.lua
@@ -1,6 +1,6 @@
 local cwd = vim.fn.getcwd()
 
-describe("linker", function()
+describe("gitlinker.linker", function()
   local assert_eq = assert.is_equal
   local assert_true = assert.is_true
   local assert_false = assert.is_false

--- a/spec/gitlinker/range_spec.lua
+++ b/spec/gitlinker/range_spec.lua
@@ -1,6 +1,6 @@
 local cwd = vim.fn.getcwd()
 
-describe("range", function()
+describe("gitlinker.range", function()
   local assert_eq = assert.is_equal
   local assert_true = assert.is_true
   local assert_false = assert.is_false


### PR DESCRIPTION
# Regression Test

## Platforms

- [x] windows
- [x] macOS
- [ ] linux

## Hosts

- [x] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [x] Use `GitLink(!)` to copy git link (or open in browser).
- [x] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
