### PR TITLE
docs: improve lazy install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ PRs are welcomed for other git host websites!
 ```lua
 require("lazy").setup({
   {
-    'linrongbin16/gitlinker.nvim',
-    config = function()
-      require('gitlinker').setup()
-    end,
-  },
+    "linrongbin16/gitlinker.nvim",
+    cmd = "GitLink",
+    opts = {},
+    keys = {
+      { "<leader>gy", "<cmd>GitLink<cr>", desc = "Yank git link" },
+    },
+  }
 })
 ```
 


### PR DESCRIPTION
The lazy.nvim install snippets can be improved:
1. `opts = {}` is all you need to setup the plugin, less code
2. It's recommended to add `cmd = "GitLink"` for lazy loading, the plugin will only load when `GitLink` is executed
3. `keys` offers an example (with ruifm's default keymapping) as an example. It will also lazy load the plugin if this keymap is triggered.

# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink(!)` to copy git link (or open in browser).
- [ ] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
