### PR TITLE
docs: add mode for lazy keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD013 MD034 MD033 -->
+<!-- markdownlint-disable MD001 MD013 MD034 MD033 -->
 
 # gitlinker.nvim
 
@@ -80,9 +80,10 @@ require("lazy").setup({
     cmd = "GitLink",
     opts = {},
     keys = {
-      { "<leader>gy", "<cmd>GitLink<cr>", desc = "Yank git link" },
+      { "<leader>gy", "<cmd>GitLink<cr>", mode = { "n", "v" }, desc = "Yank git link" },
+      { "<leader>gY", "<cmd>GitLink!<cr>", mode = { "n", "v" }, desc = "Open git link" },
     },
-  }
+  },
 })
 ```
 
@@ -251,52 +252,52 @@ vim.keymap.set(
   {"n", 'v'},
   "<leader>gl",
   "<cmd>GitLink<cr>",
-  { silent = true, noremap = true, desc = "Copy git permlink to clipboard" }
+  { silent = true, noremap = true, desc = "Yank git permlink" }
 )
 vim.keymap.set(
   {"n", 'v'},
   "<leader>gL",
   "<cmd>GitLink!<cr>",
-  { silent = true, noremap = true, desc = "Open git permlink in browser" }
+  { silent = true, noremap = true, desc = "Open git permlink" }
 )
 -- blame
 vim.keymap.set(
   {"n", 'v'},
   "<leader>gb",
   "<cmd>GitLink blame<cr>",
-  { silent = true, noremap = true, desc = "Copy git blame link to clipboard" }
+  { silent = true, noremap = true, desc = "Yank git blame link" }
 )
 vim.keymap.set(
   {"n", 'v'},
   "<leader>gB",
   "<cmd>GitLink! blame<cr>",
-  { silent = true, noremap = true, desc = "Open git blame link in browser" }
+  { silent = true, noremap = true, desc = "Open git blame link" }
 )
 -- default branch
 vim.keymap.set(
   {"n", 'v'},
   "<leader>gd",
   "<cmd>GitLink default_branch<cr>",
-  { silent = true, noremap = true, desc = "Copy default branch link to clipboard" }
+  { silent = true, noremap = true, desc = "Copy default branch link" }
 )
 vim.keymap.set(
   {"n", 'v'},
   "<leader>gD",
   "<cmd>GitLink! default_branch<cr>",
-  { silent = true, noremap = true, desc = "Open default branch link in browser" }
+  { silent = true, noremap = true, desc = "Open default branch link" }
 )
 -- default branch
 vim.keymap.set(
   {"n", 'v'},
   "<leader>gc",
   "<cmd>GitLink current_branch<cr>",
-  { silent = true, noremap = true, desc = "Copy current branch link to clipboard" }
+  { silent = true, noremap = true, desc = "Copy current branch link" }
 )
 vim.keymap.set(
   {"n", 'v'},
   "<leader>gD",
   "<cmd>GitLink! current_branch<cr>",
-  { silent = true, noremap = true, desc = "Open current branch link in browser" }
+  { silent = true, noremap = true, desc = "Open current branch link" }
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ The 2 branch components are:
 - `default_branch`
 - `current_branch`
 
-Thus you can implement your router with below lua function:
+Recall to previous use case, e.g. customize the line numbers in form `?&line=1&lines-count=2`, you can implement the router with below function:
 
 ```lua
 --- @param s string


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink(!)` to copy git link (or open in browser).
- [ ] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
