### PR TITLE
Use remote of branch rather than first remote in list (Fixes #242)

### DIFF
--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -367,7 +367,7 @@ local function get_branch_remote(cwd)
     return nil
   end
 
-  if #remotes >= 1 then
+  if #remotes == 1 then
     return remotes[1]
   end
 


### PR DESCRIPTION
Since filing #242, I have noticed that the only issue standing in the way of my feature request there, is the selection of the first remote in case multiple remotes are available. If we do not do this, as this PR proposes, the behavior will be the (in my opinion more intuitive) behavior described in #242, namely the selection of the remote of the upstream of the current branch as the remote.

Previously, in case multiple remotes were available, and the first remote did not correspond to the current branch's remote, [gitlinker failed](https://github.com/linrongbin16/gitlinker.nvim/blob/542f51784f20107ef9ecdadc47825204837efed5/lua/gitlinker/git.lua?plain=1#L397-L404) even though the 2nd, 3rd etc. remote might still match, so the proposed behavior should cause strictly fewer failing cases, and hence be backwards compatible.