### PR TITLE
fix(url): fix host ends with a colon but port is empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,6 @@ jobs:
           cp ~/.commons.nvim/version.txt ./lua/gitlinker/commons/version.txt
           cd ./lua/gitlinker/commons
           find . -type f -name '*.lua' -exec sed -i 's/require("commons/require("gitlinker.commons/g' {} \;
-      - name: Install giturlparser.lua
-        if: ${{ github.ref != 'refs/heads/master' }}
-        shell: bash
-        run: |
-          echo "pwd"
-          echo $PWD
-          git clone --depth=1 https://github.com/linrongbin16/giturlparser.lua.git ~/.giturlparser.lua
-          cp ~/.giturlparser.lua/src/giturlparser.lua ./lua/gitlinker/giturlparser.lua
       - uses: stefanzweifel/git-auto-commit-action@v5
         if: ${{ github.ref != 'refs/heads/master' }}
         with:

--- a/lua/gitlinker/giturlparser.lua
+++ b/lua/gitlinker/giturlparser.lua
@@ -1,3 +1,4 @@
+-- local inspect = require("inspect")
 local M = {}
 
 -- utils {
@@ -147,8 +148,6 @@ end
 M._parse_path = function(p, start)
   assert(type(start) == "number")
 
-  -- local inspect = require("inspect")
-
   local endswith_slash = M._endswith(p, "/")
 
   local org = nil
@@ -227,13 +226,24 @@ M._parse_host = function(p, start)
 
     -- find first slash '/' (after second ':'), the end position of port, start position of path
     local first_slash_pos = M._find(p, "/", first_colon_pos + 1)
-    if
-      type(first_slash_pos) == "number"
-      and first_slash_pos > first_colon_pos + 1
-    then
-      -- port end with '/'
-      port, port_pos = M._make(p, first_colon_pos + 1, first_slash_pos - 1)
-      path_obj = M._parse_path(p, first_slash_pos)
+    -- print(
+    --   string.format(
+    --     "_parse_host, start:%s, first_colon_pos:%s, first_slash_pos:%s\n",
+    --     inspect(start),
+    --     inspect(first_colon_pos),
+    --     inspect(first_slash_pos)
+    --   )
+    -- )
+    if type(first_slash_pos) == "number" then
+      if first_slash_pos > first_colon_pos + 1 then
+        -- port end with '/'
+        port, port_pos = M._make(p, first_colon_pos + 1, first_slash_pos - 1)
+        path_obj = M._parse_path(p, first_slash_pos)
+      else
+        assert(first_slash_pos == first_colon_pos + 1)
+        -- port is empty, host still end with '/'
+        path_obj = M._parse_path(p, first_slash_pos)
+      end
     else
       -- path not found, port end until url end
       port, port_pos = M._make(p, first_colon_pos + 1, plen)

--- a/lua/gitlinker/giturlparser.lua
+++ b/lua/gitlinker/giturlparser.lua
@@ -1,4 +1,3 @@
--- local inspect = require("inspect")
 local M = {}
 
 -- utils {
@@ -148,6 +147,8 @@ end
 M._parse_path = function(p, start)
   assert(type(start) == "number")
 
+  -- local inspect = require("inspect")
+
   local endswith_slash = M._endswith(p, "/")
 
   local org = nil
@@ -226,24 +227,13 @@ M._parse_host = function(p, start)
 
     -- find first slash '/' (after second ':'), the end position of port, start position of path
     local first_slash_pos = M._find(p, "/", first_colon_pos + 1)
-    -- print(
-    --   string.format(
-    --     "_parse_host, start:%s, first_colon_pos:%s, first_slash_pos:%s\n",
-    --     inspect(start),
-    --     inspect(first_colon_pos),
-    --     inspect(first_slash_pos)
-    --   )
-    -- )
-    if type(first_slash_pos) == "number" then
-      if first_slash_pos > first_colon_pos + 1 then
-        -- port end with '/'
-        port, port_pos = M._make(p, first_colon_pos + 1, first_slash_pos - 1)
-        path_obj = M._parse_path(p, first_slash_pos)
-      else
-        assert(first_slash_pos == first_colon_pos + 1)
-        -- port is empty, host still end with '/'
-        path_obj = M._parse_path(p, first_slash_pos)
-      end
+    if
+      type(first_slash_pos) == "number"
+      and first_slash_pos > first_colon_pos + 1
+    then
+      -- port end with '/'
+      port, port_pos = M._make(p, first_colon_pos + 1, first_slash_pos - 1)
+      path_obj = M._parse_path(p, first_slash_pos)
     else
       -- path not found, port end until url end
       port, port_pos = M._make(p, first_colon_pos + 1, plen)

--- a/spec/gitlinker_spec.lua
+++ b/spec/gitlinker_spec.lua
@@ -233,6 +233,26 @@ describe("gitlinker", function()
       )
       assert_eq(actual, routers.github_browse(lk))
     end)
+    it("ssh://git@github.com:/myorg/myrepo.git", function()
+      local lk = {
+        remote_url = "ssh://git@github.com:/myorg/myrepo.git",
+        username = "git",
+        host = "github.com",
+        org = "myorg",
+        repo = "myrepo.git",
+        rev = "399b1d05473c711fc5592a6ffc724e231c403486",
+        file = "lua/gitlinker/logger.lua",
+        lstart = 1,
+        lend = 1,
+        file_changed = false,
+      }--[[@as gitlinker.Linker]]
+      local actual = gitlinker._browse(lk)
+      assert_eq(
+        actual,
+        "https://github.com/myorg/myrepo/blob/399b1d05473c711fc5592a6ffc724e231c403486/lua/gitlinker/logger.lua?plain=1#L1"
+      )
+      assert_eq(actual, routers.github_browse(lk))
+    end)
     it("ssh://git@git.xyz.com with same lstart/lend", function()
       local lk = {
         remote_url = "ssh://git@git.xyz.com/linrongbin16/gitlinker.nvim.git",


### PR DESCRIPTION
Fix #250 .

# Regression Test

## Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Hosts

- [x] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [x] Use `GitLink(!)` to copy git link (or open in browser).
- [x] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [x] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [ ] Copy git link with 'file' and 'rev' parameters.
