### PR TITLE
ci: add code coverage back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - lint
     strategy:
       matrix:
-        nvim_version: [stable, nightly, v0.9.0]
+        nvim_version: [stable, nightly]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: rhysd/action-setup-vim@v1
-        id: vim
         with:
           neovim: true
           version: ${{ matrix.nvim_version }}
@@ -91,7 +90,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: rhysd/action-setup-vim@v1
-        id: vim
         with:
           neovim: true
           version: ${{ matrix.nvim_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,51 +80,50 @@ jobs:
         run: |
           luarocks install vusted
           vusted ./spec
-  # code_coverage:
-  #   name: Code Coverage
-  #   needs:
-  #     - lint
-  #   strategy:
-  #     matrix:
-  #       nvim_version: [stable]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: rhysd/action-setup-vim@v1
-  #       id: vim
-  #       with:
-  #         neovim: true
-  #         version: ${{ matrix.nvim_version }}
-  #     - uses: leafo/gh-actions-lua@v10
-  #       with:
-  #         # luaVersion: "luajit-2.1.0-beta3"
-  #         luaVersion: "luajit-openresty"
-  #     - uses: leafo/gh-actions-luarocks@v4
-  #     - name: Generate Coverage Reports
-  #       run: |
-  #         luarocks --lua-version=5.1 install luacov
-  #         luarocks --lua-version=5.1 install luacov-reporter-lcov
-  #         luarocks --lua-version=5.1 install vusted
-  #         vusted --coverage ./spec
-  #         echo "ls ."
-  #         ls -l .
-  #         echo "run luacov"
-  #         luacov
-  #         echo "ls ."
-  #         ls -l .
-  #         echo "tail ./luacov.report.out"
-  #         tail -n 10 ./luacov.report.out
-  #     - uses: codecov/codecov-action@v4
-  #       with:
-  #         files: luacov.report.out
-  #       env:
-  #         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  code_coverage:
+    name: Code Coverage
+    needs:
+      - lint
+    strategy:
+      matrix:
+        nvim_version: [stable]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/action-setup-vim@v1
+        id: vim
+        with:
+          neovim: true
+          version: ${{ matrix.nvim_version }}
+      - uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "luajit-openresty"
+      - uses: leafo/gh-actions-luarocks@v4
+      - name: Generate Coverage Reports
+        run: |
+          luarocks install luacov
+          luarocks install luacov-reporter-lcov
+          luarocks --lua-version=5.1 install vusted
+          vusted --coverage ./spec
+          echo "ls -l ."
+          ls -l .
+          echo "luacov -r lcov"
+          luacov -r lcov
+          echo "ls -l ."
+          ls -l .
+          echo "tail ./luacov.report.out"
+          tail -n 10 ./luacov.report.out
+      - uses: codecov/codecov-action@v4
+        with:
+          files: luacov.report.out
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   release:
     name: Release
     if: ${{ github.ref == 'refs/heads/master' }}
     needs:
       - unit_test
-      # - code_coverage
+      - code_coverage
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink(!)` to copy git link (or open in browser).
- [ ] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [ ] Copy git link with 'file' and 'rev' parameters.
