### PR TITLE
docs: add code coverage badge back

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://github.com/linrongbin16/commons.nvim"><img alt="commons.nvim" src="https://img.shields.io/badge/power_by-commons.nvim-pink" /></a>
 <a href="https://luarocks.org/modules/linrongbin16/gitlinker.nvim"><img alt="luarocks" src="https://img.shields.io/luarocks/v/linrongbin16/gitlinker.nvim" /></a>
 <a href="https://github.com/linrongbin16/gitlinker.nvim/actions/workflows/ci.yml"><img alt="ci.yml" src="https://img.shields.io/github/actions/workflow/status/linrongbin16/gitlinker.nvim/ci.yml?label=ci" /></a>
-<!-- <a href="https://app.codecov.io/github/linrongbin16/gitlinker.nvim"><img alt="codecov" src="https://img.shields.io/codecov/c/github/linrongbin16/gitlinker.nvim/main?label=codecov" /></a> -->
+<a href="https://app.codecov.io/github/linrongbin16/gitlinker.nvim"><img alt="codecov" src="https://img.shields.io/codecov/c/github/linrongbin16/gitlinker.nvim/main?label=codecov" /></a>
 </p>
 
 > Maintained fork of [ruifm's gitlinker](https://github.com/ruifm/gitlinker.nvim), refactored with bug fixes, ssh host alias, blame support and other improvements.


### PR DESCRIPTION
# Regression Test

## Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Functions

- [ ] Use `GitLink(!)` to copy git link (or open in browser).
- [ ] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [ ] Copy git link with 'file' and 'rev' parameters.
