### PR TITLE
feat(actions): improve error message for wrong actions

### DIFF
--- a/lua/gitlinker/actions.lua
+++ b/lua/gitlinker/actions.lua
@@ -1,3 +1,8 @@
+local spawn = require("gitlinker.commons.spawn")
+local str = require("gitlinker.commons.str")
+local tbl = require("gitlinker.commons.tbl")
+local logging = require("gitlinker.commons.logging")
+
 --- @alias gitlinker.Action fun(url:string):any
 
 -- copy url to clipboard
@@ -10,14 +15,62 @@ end
 -- see: https://github.com/axieax/urlview.nvim/blob/b183133fd25caa6dd98b415e0f62e51e061cd522/lua/urlview/actions.lua#L38
 --- @param url string
 local function system(url)
+  local errors = {}
+  local logger = logging.get("gitlinker")
+
+  local function _dummy() end
+  local function _error(line)
+    if str.not_empty(line) then
+      table.insert(errors, line)
+    end
+  end
+  local function _has_exitcode(result)
+    return type(result) == "table" and type(result.exitcode) == "number" and result.exitcode ~= 0
+  end
+  local function _exit(result)
+    if tbl.list_not_empty(errors) then
+      if _has_exitcode(result) then
+        logger:err(
+          string.format(
+            "failed to open url, error:%s, exitcode:%s",
+            vim.inspect(table.concat(errors, " ")),
+            vim.inspect(result.exitcode)
+          )
+        )
+      else
+        logger:err(
+          string.format("failed to open url, error:%s", vim.inspect(table.concat(errors, " ")))
+        )
+      end
+    elseif _has_exitcode(result) then
+      logger:err(string.format("failed to open url, exitcode:%s", vim.inspect(result.exitcode)))
+    end
+  end
+
   if vim.fn.has("mac") > 0 then
-    vim.fn.jobstart({ "open", url })
+    spawn.detached({ "open", url }, {
+      on_stdout = _dummy,
+      on_stderr = _error,
+    }, _exit)
+    -- vim.fn.jobstart({ "open", url }, { on_stderr = function() end })
   elseif vim.fn.has("win32") > 0 or vim.fn.has("win64") > 0 then
-    vim.fn.jobstart({ "cmd", "/C", "start", url })
+    spawn.detached({ "cmd", "/C", "start", url }, {
+      on_stdout = _dummy,
+      on_stderr = _error,
+    }, _exit)
+    -- vim.fn.jobstart({ "cmd", "/C", "start", url })
   elseif vim.fn.executable("wslview") > 0 then
-    vim.fn.jobstart({ "wslview", url })
+    spawn.detached({ "wslview", url }, {
+      on_stdout = _dummy,
+      on_stderr = _error,
+    }, _exit)
+    -- vim.fn.jobstart({ "wslview", url })
   else
-    vim.fn.jobstart({ "xdg-open", url })
+    spawn.detached({ "xdg-open", url }, {
+      on_stdout = _dummy,
+      on_stderr = _error,
+    }, _exit)
+    -- vim.fn.jobstart({ "xdg-open", url })
   end
 end
 

--- a/lua/gitlinker/actions.lua
+++ b/lua/gitlinker/actions.lua
@@ -52,25 +52,21 @@ local function system(url)
       on_stdout = _dummy,
       on_stderr = _error,
     }, _exit)
-    -- vim.fn.jobstart({ "open", url }, { on_stderr = function() end })
   elseif vim.fn.has("win32") > 0 or vim.fn.has("win64") > 0 then
     spawn.detached({ "cmd", "/C", "start", url }, {
       on_stdout = _dummy,
       on_stderr = _error,
     }, _exit)
-    -- vim.fn.jobstart({ "cmd", "/C", "start", url })
   elseif vim.fn.executable("wslview") > 0 then
     spawn.detached({ "wslview", url }, {
       on_stdout = _dummy,
       on_stderr = _error,
     }, _exit)
-    -- vim.fn.jobstart({ "wslview", url })
   else
     spawn.detached({ "xdg-open", url }, {
       on_stdout = _dummy,
       on_stderr = _error,
     }, _exit)
-    -- vim.fn.jobstart({ "xdg-open", url })
   end
 end
 


### PR DESCRIPTION
This PR improves the error message when executing the "Open URL in browser" action, thus help users debug.

Close #259 


## Test Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Test Hosts

- [x] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Test Functions

- [x] Use `GitLink(!)` to copy git link (or open in browser).
- [x] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [x] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [x] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [ ] Copy git link with 'file' and 'rev' parameters.
