### PR TITLE
docs(clipboard): move "clipboard" before highlight group

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ PRs are welcomed for other git host websites!
     - [String Template](#string-template)
     - [Lua Function](#lua-function)
   - [Create Your Own Router](#create-your-own-router)
-  - [Highlight Group](#highlight-group)
   - [Alternative Clipboard](#alternative-clipboard)
+  - [Highlight Group](#highlight-group)
 - [Development](#development)
 - [Contribute](#contribute)
 
@@ -629,12 +629,6 @@ GitLink file_only
 GitLink! file_only
 ```
 
-### Highlight Group
-
-| Highlight Group                  | Default Group | Description                          |
-| -------------------------------- | ------------- | ------------------------------------ |
-| NvimGitLinkerHighlightTextObject | Search        | highlight line ranges when copy/open |
-
 ### Alternative Clipboard
 
 You can define your own clipboard function during setup.
@@ -653,6 +647,12 @@ require('gitlinker').setup({
   end
 })
 ```
+
+### Highlight Group
+
+| Highlight Group                  | Default Group | Description                          |
+| -------------------------------- | ------------- | ------------------------------------ |
+| NvimGitLinkerHighlightTextObject | Search        | highlight line ranges when copy/open |
 
 ## Development
 


### PR DESCRIPTION
## Test Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Test Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Test Functions

- [ ] Use `GitLink(!)` to copy git link (or open in browser).
- [ ] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [ ] Copy git link with 'file' and 'rev' parameters.
