### PR TITLE
fix(routers): fix legacy routers implementation about "?plain=1"

### DIFF
--- a/lua/gitlinker/routers.lua
+++ b/lua/gitlinker/routers.lua
@@ -15,7 +15,7 @@ local Builder = {}
 
 --- @param r gitlinker.Range?
 --- @return string?
-local function LC_range(r)
+local function gitlab_line_range(r)
   if not range.is_range(r) then
     return nil
   end
@@ -29,7 +29,7 @@ end
 
 --- @param r gitlinker.Range?
 --- @return string?
-local function github_LC_range(r)
+local function github_line_range(r)
   if not range.is_range(r) then
     return nil
   end
@@ -43,7 +43,7 @@ end
 
 --- @param r gitlinker.Range?
 --- @return string?
-local function codeberg_LC_range(r)
+local function codeberg_line_range(r)
   if not range.is_range(r) then
     return nil
   end
@@ -57,7 +57,7 @@ end
 
 --- @param r gitlinker.Range?
 --- @return string?
-local function lines_range(r)
+local function bitbucket_line_range(r)
   if not range.is_range(r) then
     return nil
   end
@@ -83,11 +83,7 @@ function Builder:new(lk, range_maker)
     org = lk.org,
     repo = str.endswith(lk.repo, ".git") and lk.repo:sub(1, #lk.repo - 4) or lk.repo,
     rev = lk.rev,
-    location = string.format(
-      "%s%s",
-      lk.file .. (str.endswith(lk.file, ".md", { ignorecase = true }) and "?plain=1" or ""),
-      type(r) == "string" and r or ""
-    ),
+    location = string.format("%s%s", lk.file, type(r) == "string" and r or ""),
   }
   setmetatable(o, self)
   self.__index = self
@@ -132,28 +128,28 @@ end
 --- @param lk gitlinker.Linker
 --- @return string
 local function github_browse(lk)
-  local builder = Builder:new(lk, github_LC_range)
+  local builder = Builder:new(lk, github_line_range)
   return builder:build("blob")
 end
 
 --- @param lk gitlinker.Linker
 --- @return string
 local function gitlab_browse(lk)
-  local builder = Builder:new(lk, LC_range)
+  local builder = Builder:new(lk, gitlab_line_range)
   return builder:build("blob")
 end
 
 --- @param lk gitlinker.Linker
 --- @return string
 local function bitbucket_browse(lk)
-  local builder = Builder:new(lk, lines_range)
+  local builder = Builder:new(lk, bitbucket_line_range)
   return builder:build("src")
 end
 
 --- @param lk gitlinker.Linker
 --- @return string
 local function codeberg_browse(lk)
-  local builder = Builder:new(lk, codeberg_LC_range)
+  local builder = Builder:new(lk, codeberg_line_range)
   return builder:build("src/commit")
 end
 
@@ -164,41 +160,34 @@ end
 --- @param lk gitlinker.Linker
 --- @return string
 local function github_blame(lk)
-  local builder = Builder:new(lk, github_LC_range)
+  local builder = Builder:new(lk, github_line_range)
   return builder:build("blame")
 end
 
 --- @param lk gitlinker.Linker
 --- @return string
 local function gitlab_blame(lk)
-  local builder = Builder:new(lk, LC_range)
+  local builder = Builder:new(lk, gitlab_line_range)
   return builder:build("blame")
 end
 
 --- @param lk gitlinker.Linker
 --- @return string
 local function bitbucket_blame(lk)
-  local builder = Builder:new(lk, lines_range)
+  local builder = Builder:new(lk, bitbucket_line_range)
   return builder:build("annotate")
 end
 
 --- @param lk gitlinker.Linker
 --- @return string
 local function codeberg_blame(lk)
-  local builder = Builder:new(lk, codeberg_LC_range)
+  local builder = Builder:new(lk, codeberg_line_range)
   return builder:build("blame/commit")
 end
 
 -- blame }
 
 local M = {
-  -- Builder
-  Builder = Builder,
-
-  -- line ranges
-  LC_range = LC_range,
-  lines_range = lines_range,
-
   -- browse: `/blob`, `/src`
   samba_browse = samba_browse,
   github_browse = github_browse,

--- a/spec/gitlinker/gitlinker/router_spec.lua
+++ b/spec/gitlinker/gitlinker/router_spec.lua
@@ -8,14 +8,9 @@ describe("gitlinker.routers", function()
   before_each(function()
     vim.api.nvim_command("cd " .. cwd)
     vim.opt.swapfile = false
-    local gitlinker = require("gitlinker")
-    pcall(gitlinker.setup, {})
-    vim.cmd([[ edit lua/gitlinker.lua ]])
   end)
 
   local routers = require("gitlinker.routers")
-  local github_actions = os.getenv("GITHUB_ACTIONS") == "true"
-  local linker = require("gitlinker.linker")
   describe("[samba_browse]", function()
     it("test1", function()
       local lk = {
@@ -61,6 +56,104 @@ describe("gitlinker.routers", function()
       assert_eq(
         actual,
         "https://git.samba.org/?p=linrongbin16/lin.nvim;a=blob;f=README.md;hb=e3ef741ac8814fc0895e26772c5059af2f064543#l1"
+      )
+    end)
+  end)
+
+  describe("[github_browse]", function()
+    it("test1", function()
+      local lk = {
+        current_branch = "dev-plugin",
+        default_branch = "main",
+        file = "vim.toml",
+        file_changed = false,
+        host = "github.com",
+        lend = 1,
+        lstart = 1,
+        org = "linrongbin16",
+        protocol = "https",
+        remote_url = "https://github.com/linrongbin16/lin.nvim",
+        repo = "lin.nvim",
+        rev = "e3ef741ac8814fc0895e26772c5059af2f064543",
+        user = "linrongbin16",
+      }
+      local actual = routers.github_browse(lk)
+      print(string.format("github_browse:%s", vim.inspect(actual)))
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/lin.nvim/blob/e3ef741ac8814fc0895e26772c5059af2f064543/vim.toml?plain=1#L1"
+      )
+    end)
+    it("test2", function()
+      local lk = {
+        current_branch = "dev-plugin",
+        default_branch = "main",
+        file = "README.md",
+        file_changed = false,
+        host = "github.com",
+        lend = 1,
+        lstart = 1,
+        org = "linrongbin16",
+        protocol = "https",
+        remote_url = "https://github.com/linrongbin16/lin.nvim",
+        repo = "lin.nvim",
+        rev = "e3ef741ac8814fc0895e26772c5059af2f064543",
+        user = "linrongbin16",
+      }
+      local actual = routers.github_browse(lk)
+      print(string.format("github_browse:%s", vim.inspect(actual)))
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/lin.nvim/blob/e3ef741ac8814fc0895e26772c5059af2f064543/README.md?plain=1#L1"
+      )
+    end)
+  end)
+
+  describe("[github_blame]", function()
+    it("test1", function()
+      local lk = {
+        current_branch = "dev-plugin",
+        default_branch = "main",
+        file = "vim.toml",
+        file_changed = false,
+        host = "github.com",
+        lend = 1,
+        lstart = 1,
+        org = "linrongbin16",
+        protocol = "https",
+        remote_url = "https://github.com/linrongbin16/lin.nvim",
+        repo = "lin.nvim",
+        rev = "e3ef741ac8814fc0895e26772c5059af2f064543",
+        user = "linrongbin16",
+      }
+      local actual = routers.github_blame(lk)
+      print(string.format("github_blame:%s", vim.inspect(actual)))
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/lin.nvim/blame/e3ef741ac8814fc0895e26772c5059af2f064543/vim.toml?plain=1#L1"
+      )
+    end)
+    it("test2", function()
+      local lk = {
+        current_branch = "dev-plugin",
+        default_branch = "main",
+        file = "README.md",
+        file_changed = false,
+        host = "github.com",
+        lend = 1,
+        lstart = 1,
+        org = "linrongbin16",
+        protocol = "https",
+        remote_url = "https://github.com/linrongbin16/lin.nvim",
+        repo = "lin.nvim",
+        rev = "e3ef741ac8814fc0895e26772c5059af2f064543",
+        user = "linrongbin16",
+      }
+      local actual = routers.github_blame(lk)
+      print(string.format("github_blame:%s", vim.inspect(actual)))
+      assert_eq(
+        actual,
+        "https://github.com/linrongbin16/lin.nvim/blame/e3ef741ac8814fc0895e26772c5059af2f064543/README.md?plain=1#L1"
       )
     end)
   end)


### PR DESCRIPTION
Fix #289 .

## Test Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Test Hosts

- [x] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Test Functions

- [x] Use `GitLink(!)` to copy git link (or open in browser).
- [x] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [ ] Copy git link with 'file' and 'rev' parameters.
