### PR TITLE
refactor(actions): try use pwsh/powershell/cmd/wslview to open url

### DIFF
--- a/lua/gitlinker/actions.lua
+++ b/lua/gitlinker/actions.lua
@@ -12,10 +12,16 @@ end
 local function system(url)
   if vim.fn.has("mac") > 0 then
     vim.fn.jobstart({ "open", url })
-  elseif vim.fn.has("win32") > 0 or vim.fn.has("win64") > 0 or vim.fn.has('wsl') > 0 then
-    vim.fn.jobstart({ "cmd.exe", "/C", "start", url })
-  elseif vim.fn.executable("wslview") > 0 then
-    vim.fn.jobstart({ "wslview", url })
+  elseif vim.fn.has("win32") > 0 or vim.fn.has("win64") > 0 then
+    if vim.fn.executable("pwsh.exe") > 0 then
+      vim.fn.jobstart({ "pwsh.exe", "-Command", "Start-Process", url })
+    elseif vim.fn.executable("powershell.exe") > 0 then
+      vim.fn.jobstart({ "powershell.exe", "-Command", "Start-Process", url })
+    elseif vim.fn.executable("cmd.exe") > 0 then
+      vim.fn.jobstart({ "cmd.exe", "/C", "start", url })
+    elseif vim.fn.has("wsl") > 0 and vim.fn.executable("wslview") > 0 then
+      vim.fn.jobstart({ "wslview", url })
+    end
   else
     vim.fn.jobstart({ "xdg-open", url })
   end


### PR DESCRIPTION
Refactor #292 

## Test Platforms

- [x] windows
- [ ] macOS
- [ ] linux

## Test Hosts

- [x] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Test Functions

- [x] Use `GitLink(!)` to copy git link (or open in browser).
- [ ] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [ ] Copy git link with 'file' and 'rev' parameters.
