### PR TITLE
feat(timeout): add "timeout_ms" and "max_parent_commits" options

### DIFF
--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -203,16 +203,6 @@ local _link = function(opts)
 
   local lk = linker.make_linker(opts.remote, opts.file, opts.rev, opts.timeout_ms)
   if not lk then
-    vim.notify(
-      string.format(
-        "fatal: failed to generate git permlink for remote:%s, file:%s, rev:%s, timeout:%s",
-        vim.inspect(opts.remote),
-        vim.inspect(opts.file),
-        vim.inspect(opts.rev),
-        vim.inspect(opts.timeout_ms)
-      ),
-      vim.log.levels.ERROR
-    )
     return nil
   end
   lk.lstart = opts.lstart

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -195,14 +195,24 @@ local function _blame(lk)
   return _router("blame", lk)
 end
 
---- @param opts {action:gitlinker.Action|boolean,router:gitlinker.Router,lstart:integer,lend:integer,message:boolean?,highlight_duration:integer?,remote:string?,file:string?,rev:string?}
+--- @param opts {action:gitlinker.Action|boolean,router:gitlinker.Router,lstart:integer,lend:integer,message:boolean?,highlight_duration:integer?,timeout_ms:integer?,remote:string?,file:string?,rev:string?}
 --- @return string?
 local _link = function(opts)
   local confs = configs.get()
   -- logger.debug("[link] merged opts: %s", vim.inspect(opts))
 
-  local lk = linker.make_linker(opts.remote, opts.file, opts.rev)
+  local lk = linker.make_linker(opts.remote, opts.file, opts.rev, opts.timeout_ms)
   if not lk then
+    vim.notify(
+      string.format(
+        "fatal: failed to generate git permlink for remote:%s, file:%s, rev:%s, timeout:%s",
+        vim.inspect(opts.remote),
+        vim.inspect(opts.file),
+        vim.inspect(opts.rev),
+        vim.inspect(opts.timeout_ms)
+      ),
+      vim.log.levels.ERROR
+    )
     return nil
   end
   lk.lstart = opts.lstart

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -195,13 +195,14 @@ local function _blame(lk)
   return _router("blame", lk)
 end
 
---- @param opts {action:gitlinker.Action|boolean,router:gitlinker.Router,lstart:integer,lend:integer,message:boolean?,highlight_duration:integer?,timeout_ms:integer?,remote:string?,file:string?,rev:string?}
+--- @param opts {action:gitlinker.Action|boolean,router:gitlinker.Router,lstart:integer,lend:integer,message:boolean?,highlight_duration:integer?,timeout_ms:integer?,max_parent_commits:integer?,remote:string?,file:string?,rev:string?}
 --- @return string?
 local _link = function(opts)
   local confs = configs.get()
   -- logger.debug("[link] merged opts: %s", vim.inspect(opts))
 
-  local lk = linker.make_linker(opts.remote, opts.file, opts.rev, opts.timeout_ms)
+  local lk =
+    linker.make_linker(opts.remote, opts.file, opts.rev, opts.timeout_ms, opts.max_parent_commits)
   if not lk then
     return nil
   end

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -199,10 +199,10 @@ end
 --- @return string?
 local _link = function(opts)
   local confs = configs.get()
-  -- logger.debug("[link] merged opts: %s", vim.inspect(opts))
+  log.debug(string.format("|link| opts:%s, confs:%s", vim.inspect(opts), vim.inspect(confs)))
 
   local lk =
-    linker.make_linker(opts.remote, opts.file, opts.rev, opts.timeout_ms, opts.max_parent_commits)
+    linker.make_linker(opts.remote, opts.file, opts.rev, confs.timeout_ms, confs.max_parent_commits)
   if not lk then
     return nil
   end

--- a/lua/gitlinker/configs.lua
+++ b/lua/gitlinker/configs.lua
@@ -7,6 +7,9 @@ local Defaults = {
   -- highlight the linked region
   highlight_duration = 500,
 
+  -- Git command running timeout in milliseconds
+  timeout_ms = 1000,
+
   -- user command
   command = {
     name = "GitLink",

--- a/lua/gitlinker/configs.lua
+++ b/lua/gitlinker/configs.lua
@@ -10,6 +10,9 @@ local Defaults = {
   -- Git command running timeout in milliseconds
   timeout_ms = 1000,
 
+  -- Max commits git will use to match the commit between local and remote git repository.
+  max_parent_commits = 10,
+
   -- user command
   command = {
     name = "GitLink",

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -272,8 +272,9 @@ end
 
 --- @param remote string
 --- @param cwd string?
+--- @param max_parent_commits integer
 --- @return string?
-local function get_closest_remote_compatible_rev(remote, cwd)
+local function get_closest_remote_compatible_rev(remote, cwd, max_parent_commits)
   assert(remote, "remote cannot be nil")
 
   -- try upstream branch HEAD (a.k.a @{u})
@@ -304,7 +305,6 @@ local function get_closest_remote_compatible_rev(remote, cwd)
   end
 
   -- try last 5 parent commits
-  local max_parent_commits = 10
   if remote_fetch_configured then
     for i = 1, max_parent_commits do
       local revspec = "HEAD~" .. i

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -270,6 +270,14 @@ local function resolve_host(host)
   return nil
 end
 
+--- @return integer
+local function now_milliseconds()
+  local ts = uv.clock_gettime("monotonic") --[[@as {sec:integer,nsec:integer} ]]
+  local t1 = ts.sec * 1000
+  local t2 = ts.nsec / 1000000
+  return math.ceil(t1 + t2)
+end
+
 --- @param start_at integer
 --- @param timeout_ms integer?
 --- @return boolean

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -270,11 +270,26 @@ local function resolve_host(host)
   return nil
 end
 
+--- @param start_at integer
+--- @param timeout_ms integer?
+--- @return boolean
+local function is_timeout(start_at, timeout_ms)
+  return type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms
+end
+
 --- @param remote string
 --- @param cwd string?
 --- @param max_parent_commits integer
+--- @param start_at integer
+--- @param timeout_ms integer?
 --- @return string?
-local function get_closest_remote_compatible_rev(remote, cwd, max_parent_commits)
+local function get_closest_remote_compatible_rev(
+  remote,
+  cwd,
+  max_parent_commits,
+  start_at,
+  timeout_ms
+)
   assert(remote, "remote cannot be nil")
 
   -- try upstream branch HEAD (a.k.a @{u})
@@ -303,6 +318,10 @@ local function get_closest_remote_compatible_rev(remote, cwd, max_parent_commits
       return head_rev
     end
   end
+  if is_timeout(start_at, timeout_ms) then
+    log.err("fatal: timeout when finding closest compatible rev")
+    return nil
+  end
 
   -- try last 5 parent commits
   if remote_fetch_configured then
@@ -313,6 +332,10 @@ local function get_closest_remote_compatible_rev(remote, cwd, max_parent_commits
         if rev then
           return rev
         end
+        if is_timeout(start_at, timeout_ms) then
+          log.err("fatal: timeout when finding closest compatible rev")
+          return nil
+        end
       end
     end
   else
@@ -321,6 +344,10 @@ local function get_closest_remote_compatible_rev(remote, cwd, max_parent_commits
       local rev = _get_rev(revspec, cwd)
       if rev then
         return rev
+      end
+      if is_timeout(start_at, timeout_ms) then
+        log.err("fatal: timeout when finding closest compatible rev")
+        return nil
       end
     end
   end

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -303,9 +303,10 @@ local function get_closest_remote_compatible_rev(remote, cwd)
     end
   end
 
-  -- try last 50 parent commits
+  -- try last 5 parent commits
+  local max_parent_commits = 5
   if remote_fetch_configured then
-    for i = 1, 50 do
+    for i = 1, max_parent_commits do
       local revspec = "HEAD~" .. i
       if _is_rev_in_remote(revspec, remote, cwd) then
         local rev = _get_rev(revspec, cwd)
@@ -315,7 +316,7 @@ local function get_closest_remote_compatible_rev(remote, cwd)
       end
     end
   else
-    for i = 1, 50 do
+    for i = 1, max_parent_commits do
       local revspec = "HEAD~" .. i
       local rev = _get_rev(revspec, cwd)
       if rev then

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -1,6 +1,9 @@
 local log = require("gitlinker.commons.log")
 local str = require("gitlinker.commons.str")
 local async = require("gitlinker.commons.async")
+
+local util = require("gitlinker.util")
+
 local uv = vim.uv or vim.loop
 
 --- @class gitlinker.CmdResult
@@ -270,21 +273,6 @@ local function resolve_host(host)
   return nil
 end
 
---- @return integer
-local function now_milliseconds()
-  local ts = uv.clock_gettime("monotonic") --[[@as {sec:integer,nsec:integer} ]]
-  local t1 = ts.sec * 1000
-  local t2 = ts.nsec / 1000000
-  return math.ceil(t1 + t2)
-end
-
---- @param start_at integer
---- @param timeout_ms integer?
---- @return boolean
-local function is_timeout(start_at, timeout_ms)
-  return type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms
-end
-
 --- @param remote string
 --- @param cwd string?
 --- @param max_parent_commits integer
@@ -326,7 +314,7 @@ local function get_closest_remote_compatible_rev(
       return head_rev
     end
   end
-  if is_timeout(start_at, timeout_ms) then
+  if util.is_timeout(start_at, timeout_ms) then
     log.err("fatal: timeout when finding closest compatible rev")
     return nil
   end
@@ -340,7 +328,7 @@ local function get_closest_remote_compatible_rev(
         if rev then
           return rev
         end
-        if is_timeout(start_at, timeout_ms) then
+        if util.is_timeout(start_at, timeout_ms) then
           log.err("fatal: timeout when finding closest compatible rev")
           return nil
         end
@@ -353,7 +341,7 @@ local function get_closest_remote_compatible_rev(
       if rev then
         return rev
       end
-      if is_timeout(start_at, timeout_ms) then
+      if util.is_timeout(start_at, timeout_ms) then
         log.err("fatal: timeout when finding closest compatible rev")
         return nil
       end

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -304,7 +304,7 @@ local function get_closest_remote_compatible_rev(remote, cwd)
   end
 
   -- try last 5 parent commits
-  local max_parent_commits = 5
+  local max_parent_commits = 10
   if remote_fetch_configured then
     for i = 1, max_parent_commits do
       local revspec = "HEAD~" .. i

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -121,7 +121,13 @@ local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
   -- )
 
   if not rev_provided then
-    rev = git.get_closest_remote_compatible_rev(remote, cwd, max_parent_commits --[[@as integer]])
+    rev = git.get_closest_remote_compatible_rev(
+      remote,
+      cwd,
+      max_parent_commits --[[@as integer]],
+      start_at,
+      timeout_ms
+    )
   end
   if str.empty(rev) then
     return nil

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -51,6 +51,7 @@ local function make_linker(remote, file, rev, timeout_ms)
     return nil
   end
   if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
+    log.err("fatal: timeout when locate git repository root")
     return nil
   end
 

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -4,7 +4,7 @@ local async = require("gitlinker.commons.async")
 local uv = vim.uv or vim.loop
 
 local git = require("gitlinker.git")
-local path = require("gitlinker.path")
+local util = require("gitlinker.util")
 local giturlparser = require("gitlinker.giturlparser")
 
 --- @return string?
@@ -27,9 +27,12 @@ end
 --- @return integer
 local function now_milliseconds()
   local ts = uv.clock_gettime("monotonic") --[[@as {sec:integer,nsec:integer} ]]
+  log.debug(string.format("now_ts:%s", vim.inspect(ts)))
   local t1 = ts.sec * 1000
   local t2 = ts.nsec / 1000000
-  return math.ceil(t1 + t2)
+  local ms = math.ceil(t1 + t2)
+  log.debug(string.format("now_ms:%s", vim.inspect(ms)))
+  return ms
 end
 
 --- @param start_at integer
@@ -141,7 +144,7 @@ local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
   async.await(1, vim.schedule)
 
   if not file_provided then
-    local buf_path_on_root = path.buffer_relpath(root) --[[@as string]]
+    local buf_path_on_root = util.buffer_relative_path(root) --[[@as string]]
     local buf_path_encoded = vim.uri_encode(buf_path_on_root) --[[@as string]]
     -- logger.debug(
     --     "|linker - Linker:make| root:%s, buf_path_on_root:%s",
@@ -171,7 +174,7 @@ local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
 
   local file_changed = false
   if not file_provided then
-    local buf_path_on_cwd = path.buffer_relpath() --[[@as string]]
+    local buf_path_on_cwd = util.buffer_relative_path() --[[@as string]]
     file_changed = git.file_has_changed(buf_path_on_cwd, rev --[[@as string]], cwd)
     -- logger.debug(
     --     "|linker - Linker:make| buf_path_on_cwd:%s",

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -32,6 +32,13 @@ local function now_milliseconds()
   return math.ceil(t1 + t2)
 end
 
+--- @param start_at integer
+--- @param timeout_ms integer?
+--- @return boolean
+local function is_timeout(start_at, timeout_ms)
+  return type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms
+end
+
 --- @alias gitlinker.Linker {remote_url:string,protocol:string?,username:string?,password:string?,host:string,port:string?,org:string?,user:string?,repo:string,rev:string,file:string,lstart:integer,lend:integer,file_changed:boolean,default_branch:string?,current_branch:string?}
 --- @param remote string?
 --- @param file string?
@@ -50,8 +57,8 @@ local function make_linker(remote, file, rev, timeout_ms)
   if not root then
     return nil
   end
-  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
-    log.err("fatal: timeout when locate git repository root")
+  if is_timeout(start_at, timeout_ms) then
+    log.err("fatal: timeout when finding git repository root")
     return nil
   end
 
@@ -61,7 +68,8 @@ local function make_linker(remote, file, rev, timeout_ms)
   if not remote then
     return nil
   end
-  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
+  if is_timeout(start_at, timeout_ms) then
+    log.err("fatal: timeout when getting git repository remote branch")
     return nil
   end
   -- logger.debug("|linker - Linker:make| remote:%s", vim.inspect(remote))
@@ -70,7 +78,8 @@ local function make_linker(remote, file, rev, timeout_ms)
   if not remote_url then
     return nil
   end
-  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
+  if is_timeout(start_at, timeout_ms) then
+    log.err("fatal: timeout when getting git repository remote url")
     return nil
   end
 
@@ -95,7 +104,8 @@ local function make_linker(remote, file, rev, timeout_ms)
   if not resolved_host then
     return nil
   end
-  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
+  if is_timeout(start_at, timeout_ms) then
+    log.err("fatal: timeout when resolving git host with ssh alias")
     return nil
   end
 
@@ -110,7 +120,8 @@ local function make_linker(remote, file, rev, timeout_ms)
   if str.empty(rev) then
     return nil
   end
-  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
+  if is_timeout(start_at, timeout_ms) then
+    log.err("fatal: timeout when trying to get closest compatible remote rev")
     return nil
   end
   -- logger.debug("|linker - Linker:make| rev:%s", vim.inspect(rev))
@@ -134,7 +145,8 @@ local function make_linker(remote, file, rev, timeout_ms)
   else
     file = vim.uri_encode(file)
   end
-  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
+  if is_timeout(start_at, timeout_ms) then
+    log.err("fatal: timeout when getting filename in remote git repository")
     return nil
   end
 
@@ -154,8 +166,16 @@ local function make_linker(remote, file, rev, timeout_ms)
     --     vim.inspect(buf_path_on_cwd)
     -- )
   end
+  if is_timeout(start_at, timeout_ms) then
+    log.err("fatal: timeout when detecting whether local file is changed")
+    return nil
+  end
 
   local default_branch = git.get_default_branch(remote, cwd)
+  if is_timeout(start_at, timeout_ms) then
+    log.err("fatal: timeout when getting default branch")
+    return nil
+  end
   local current_branch = git.get_current_branch(cwd)
 
   local o = {

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -39,14 +39,20 @@ local function is_timeout(start_at, timeout_ms)
   return type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms
 end
 
+local MAX_PARENT_COMMITS = 10
+
 --- @alias gitlinker.Linker {remote_url:string,protocol:string?,username:string?,password:string?,host:string,port:string?,org:string?,user:string?,repo:string,rev:string,file:string,lstart:integer,lend:integer,file_changed:boolean,default_branch:string?,current_branch:string?}
 --- @param remote string?
 --- @param file string?
 --- @param rev string?
 --- @param timeout_ms integer?
+--- @param max_parent_commits integer?
 --- @return gitlinker.Linker?
-local function make_linker(remote, file, rev, timeout_ms)
+local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
   local start_at = now_milliseconds()
+  if type(max_parent_commits) ~= "number" then
+    max_parent_commits = MAX_PARENT_COMMITS
+  end
 
   local cwd = _get_buf_dir()
 
@@ -115,7 +121,7 @@ local function make_linker(remote, file, rev, timeout_ms)
   -- )
 
   if not rev_provided then
-    rev = git.get_closest_remote_compatible_rev(remote, cwd)
+    rev = git.get_closest_remote_compatible_rev(remote, cwd, max_parent_commits --[[@as integer]])
   end
   if str.empty(rev) then
     return nil

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -1,6 +1,7 @@
 local log = require("gitlinker.commons.log")
 local str = require("gitlinker.commons.str")
 local async = require("gitlinker.commons.async")
+local uv = vim.uv or vim.loop
 
 local git = require("gitlinker.git")
 local path = require("gitlinker.path")
@@ -23,12 +24,23 @@ local function _get_buf_dir()
   return buf_dir
 end
 
+--- @return integer
+local function now_milliseconds()
+  local ts = uv.clock_gettime("monotonic") --[[@as {sec:integer,nsec:integer} ]]
+  local t1 = ts.sec * 1000
+  local t2 = ts.nsec / 1000000
+  return math.ceil(t1 + t2)
+end
+
 --- @alias gitlinker.Linker {remote_url:string,protocol:string?,username:string?,password:string?,host:string,port:string?,org:string?,user:string?,repo:string,rev:string,file:string,lstart:integer,lend:integer,file_changed:boolean,default_branch:string?,current_branch:string?}
 --- @param remote string?
 --- @param file string?
 --- @param rev string?
+--- @param timeout_ms integer?
 --- @return gitlinker.Linker?
-local function make_linker(remote, file, rev)
+local function make_linker(remote, file, rev, timeout_ms)
+  local start_at = now_milliseconds()
+
   local cwd = _get_buf_dir()
 
   local file_provided = str.not_empty(file)
@@ -38,6 +50,9 @@ local function make_linker(remote, file, rev)
   if not root then
     return nil
   end
+  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
+    return nil
+  end
 
   if str.empty(remote) then
     remote = git.get_branch_remote(cwd)
@@ -45,10 +60,16 @@ local function make_linker(remote, file, rev)
   if not remote then
     return nil
   end
+  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
+    return nil
+  end
   -- logger.debug("|linker - Linker:make| remote:%s", vim.inspect(remote))
 
   local remote_url = git.get_remote_url(remote, cwd)
   if not remote_url then
+    return nil
+  end
+  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
     return nil
   end
 
@@ -73,6 +94,9 @@ local function make_linker(remote, file, rev)
   if not resolved_host then
     return nil
   end
+  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
+    return nil
+  end
 
   -- logger.debug(
   --     "|linker - Linker:make| remote_url:%s",
@@ -83,6 +107,9 @@ local function make_linker(remote, file, rev)
     rev = git.get_closest_remote_compatible_rev(remote, cwd)
   end
   if str.empty(rev) then
+    return nil
+  end
+  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
     return nil
   end
   -- logger.debug("|linker - Linker:make| rev:%s", vim.inspect(rev))
@@ -105,6 +132,9 @@ local function make_linker(remote, file, rev)
     file = buf_path_encoded
   else
     file = vim.uri_encode(file)
+  end
+  if type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms then
+    return nil
   end
 
   -- logger.debug(

--- a/lua/gitlinker/linker.lua
+++ b/lua/gitlinker/linker.lua
@@ -1,7 +1,6 @@
 local log = require("gitlinker.commons.log")
 local str = require("gitlinker.commons.str")
 local async = require("gitlinker.commons.async")
-local uv = vim.uv or vim.loop
 
 local git = require("gitlinker.git")
 local util = require("gitlinker.util")
@@ -24,24 +23,6 @@ local function _get_buf_dir()
   return buf_dir
 end
 
---- @return integer
-local function now_milliseconds()
-  local ts = uv.clock_gettime("monotonic") --[[@as {sec:integer,nsec:integer} ]]
-  log.debug(string.format("now_ts:%s", vim.inspect(ts)))
-  local t1 = ts.sec * 1000
-  local t2 = ts.nsec / 1000000
-  local ms = math.ceil(t1 + t2)
-  log.debug(string.format("now_ms:%s", vim.inspect(ms)))
-  return ms
-end
-
---- @param start_at integer
---- @param timeout_ms integer?
---- @return boolean
-local function is_timeout(start_at, timeout_ms)
-  return type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms
-end
-
 local MAX_PARENT_COMMITS = 10
 
 --- @alias gitlinker.Linker {remote_url:string,protocol:string?,username:string?,password:string?,host:string,port:string?,org:string?,user:string?,repo:string,rev:string,file:string,lstart:integer,lend:integer,file_changed:boolean,default_branch:string?,current_branch:string?}
@@ -52,7 +33,7 @@ local MAX_PARENT_COMMITS = 10
 --- @param max_parent_commits integer?
 --- @return gitlinker.Linker?
 local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
-  local start_at = now_milliseconds()
+  local start_at = util.now_milliseconds()
   if type(max_parent_commits) ~= "number" then
     max_parent_commits = MAX_PARENT_COMMITS
   end
@@ -66,7 +47,7 @@ local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
   if not root then
     return nil
   end
-  if is_timeout(start_at, timeout_ms) then
+  if util.is_timeout(start_at, timeout_ms) then
     log.err("fatal: timeout when finding git repository root")
     return nil
   end
@@ -77,7 +58,7 @@ local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
   if not remote then
     return nil
   end
-  if is_timeout(start_at, timeout_ms) then
+  if util.is_timeout(start_at, timeout_ms) then
     log.err("fatal: timeout when getting git repository remote branch")
     return nil
   end
@@ -87,7 +68,7 @@ local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
   if not remote_url then
     return nil
   end
-  if is_timeout(start_at, timeout_ms) then
+  if util.is_timeout(start_at, timeout_ms) then
     log.err("fatal: timeout when getting git repository remote url")
     return nil
   end
@@ -113,7 +94,7 @@ local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
   if not resolved_host then
     return nil
   end
-  if is_timeout(start_at, timeout_ms) then
+  if util.is_timeout(start_at, timeout_ms) then
     log.err("fatal: timeout when resolving git host with ssh alias")
     return nil
   end
@@ -135,7 +116,7 @@ local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
   if str.empty(rev) then
     return nil
   end
-  if is_timeout(start_at, timeout_ms) then
+  if util.is_timeout(start_at, timeout_ms) then
     log.err("fatal: timeout when trying to get closest compatible remote rev")
     return nil
   end
@@ -160,7 +141,7 @@ local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
   else
     file = vim.uri_encode(file)
   end
-  if is_timeout(start_at, timeout_ms) then
+  if util.is_timeout(start_at, timeout_ms) then
     log.err("fatal: timeout when getting filename in remote git repository")
     return nil
   end
@@ -181,13 +162,13 @@ local function make_linker(remote, file, rev, timeout_ms, max_parent_commits)
     --     vim.inspect(buf_path_on_cwd)
     -- )
   end
-  if is_timeout(start_at, timeout_ms) then
+  if util.is_timeout(start_at, timeout_ms) then
     log.err("fatal: timeout when detecting whether local file is changed")
     return nil
   end
 
   local default_branch = git.get_default_branch(remote, cwd)
-  if is_timeout(start_at, timeout_ms) then
+  if util.is_timeout(start_at, timeout_ms) then
     log.err("fatal: timeout when getting default branch")
     return nil
   end

--- a/lua/gitlinker/util.lua
+++ b/lua/gitlinker/util.lua
@@ -14,6 +14,12 @@ local function buffer_relative_path(cwd)
   bufpath = vim.fn.resolve(bufpath)
   bufpath = path.normalize(bufpath, { double_backslash = true, expand = true })
 
+  -- logger.debug(
+  --     "|path.buffer_relpath| enter, cwd:%s, bufpath:%s",
+  --     vim.inspect(cwd),
+  --     vim.inspect(bufpath)
+  -- )
+
   local result = nil
   if string.len(bufpath) >= string.len(cwd) and bufpath:sub(1, #cwd) == cwd then
     result = bufpath:sub(#cwd + 1)
@@ -40,7 +46,18 @@ end
 --- @param timeout_ms integer?
 --- @return boolean
 local function is_timeout(start_at, timeout_ms)
-  return type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms
+  local now = now_milliseconds()
+  local yes = type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms
+  log.debug(
+    string.format(
+      "is_timeout start_at:%s,now:%s,timeout_ms:%s,yes:%s",
+      vim.inspect(start_at),
+      vim.inspect(now),
+      vim.inspect(timeout_ms),
+      vim.inspect(yes)
+    )
+  )
+  return yes
 end
 
 local M = {

--- a/lua/gitlinker/util.lua
+++ b/lua/gitlinker/util.lua
@@ -1,6 +1,6 @@
 --- @param cwd string?
 --- @return string?
-local function buffer_relpath(cwd)
+local function buffer_relative_path(cwd)
   local path = require("gitlinker.commons.path")
 
   cwd = cwd or vim.fn.getcwd()
@@ -29,7 +29,7 @@ local function buffer_relpath(cwd)
 end
 
 local M = {
-  buffer_relpath = buffer_relpath,
+  buffer_relative_path = buffer_relative_path,
 }
 
 return M

--- a/lua/gitlinker/util.lua
+++ b/lua/gitlinker/util.lua
@@ -1,3 +1,6 @@
+local log = require("gitlinker.commons.log")
+local uv = vim.uv or vim.loop
+
 --- @param cwd string?
 --- @return string?
 local function buffer_relative_path(cwd)
@@ -11,12 +14,6 @@ local function buffer_relative_path(cwd)
   bufpath = vim.fn.resolve(bufpath)
   bufpath = path.normalize(bufpath, { double_backslash = true, expand = true })
 
-  -- logger.debug(
-  --     "|path.buffer_relpath| enter, cwd:%s, bufpath:%s",
-  --     vim.inspect(cwd),
-  --     vim.inspect(bufpath)
-  -- )
-
   local result = nil
   if string.len(bufpath) >= string.len(cwd) and bufpath:sub(1, #cwd) == cwd then
     result = bufpath:sub(#cwd + 1)
@@ -28,8 +25,28 @@ local function buffer_relative_path(cwd)
   return result
 end
 
+--- @return integer
+local function now_milliseconds()
+  local ts = uv.clock_gettime("monotonic") --[[@as {sec:integer,nsec:integer} ]]
+  log.debug(string.format("now_ts:%s", vim.inspect(ts)))
+  local t1 = ts.sec * 1000
+  local t2 = ts.nsec / 1000000
+  local ms = math.ceil(t1 + t2)
+  log.debug(string.format("now_ms:%s", vim.inspect(ms)))
+  return ms
+end
+
+--- @param start_at integer
+--- @param timeout_ms integer?
+--- @return boolean
+local function is_timeout(start_at, timeout_ms)
+  return type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms
+end
+
 local M = {
   buffer_relative_path = buffer_relative_path,
+  now_milliseconds = now_milliseconds,
+  is_timeout = is_timeout,
 }
 
 return M

--- a/spec/gitlinker/gitlinker/git_spec.lua
+++ b/spec/gitlinker/gitlinker/git_spec.lua
@@ -13,7 +13,7 @@ describe("gitlinker.git", function()
 
   local async = require("gitlinker.commons.async")
   local git = require("gitlinker.git")
-  local path = require("gitlinker.path")
+  local util = require("gitlinker.util")
   local gitlinker = require("gitlinker")
   pcall(gitlinker.setup, {})
   describe("[git]", function()
@@ -89,7 +89,7 @@ describe("gitlinker.git", function()
         assert_eq(type(rev), "string")
         assert_true(string.len(rev) > 0)
 
-        local bufpath = path.buffer_relpath() --[[@as string]]
+        local bufpath = util.buffer_relative_path() --[[@as string]]
         if not bufpath then
           assert_true(bufpath == nil)
           return


### PR DESCRIPTION
Close #296 

Adds a "timeout_ms" (in milliseconds) option, by default it is `1000ms` (`1 sec`).

As this plugin will run multiple git commands in a local git repository to find out all the correct remote git host information it needs to construct a remote git permlink. If running commands cost too long time, which is greater than "timeout_ms", then it will directly return an error message.

Also adds a "max_parent_commits" (count) option, by default it is `10`.

This plugin will try to find the correct commit ID to match between local git repo and remote git repo, with following method:

1. First try `git rev-parse @{u}`, in a correctly remote-url configured git repo, this should work.
2. Then try `git rev-parse HEAD` to find out the latest remote repo commit ID.
3. At last, try `git rev-parse HEAD~{1,10}` to find out a closest compatible commit ID in remote git repo. In this case, the `10` is the maximum parent commits we will try. In previous implement, this max value is `50`, which can cost a long time. In this PR, I add this "max_parent_commits" option to let user decide how many commits they want to find.

## Test Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Test Hosts

- [x] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Test Functions

- [x] Use `GitLink(!)` to copy git link (or open in browser).
- [x] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [x] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [x] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [ ] Copy git link with 'file' and 'rev' parameters.
