### PR TITLE
DON'T MERGE: test `timeout` branch

### DIFF
--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -199,7 +199,7 @@ end
 --- @return string?
 local _link = function(opts)
   local confs = configs.get()
-  log.debug(string.format("|link| opts:%s, confs:%s", vim.inspect(opts), vim.inspect(confs)))
+  -- log.debug(string.format("|link| opts:%s, confs:%s", vim.inspect(opts), vim.inspect(confs)))
 
   local lk =
     linker.make_linker(opts.remote, opts.file, opts.rev, confs.timeout_ms, confs.max_parent_commits)

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -51,8 +51,9 @@ local function _run_cmd_async(args, cwd, callback)
 
   --- @param completed vim.SystemCompleted
   local function on_exit(completed)
+    local n = math.floor(math.random(1000000, 1000000000))
     local j = 0
-    for i = 1, 1000000000 do
+    for i = 1, n do
       j = j + i
     end
     log.debug(string.format("j:%d", j))

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -51,7 +51,7 @@ local function _run_cmd_async(args, cwd, callback)
 
   --- @param completed vim.SystemCompleted
   local function on_exit(completed)
-    local n = 100000000
+    local n = 200000000
     local j = 0
     for i = 1, n do
       j = j + i

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -51,6 +51,11 @@ local function _run_cmd_async(args, cwd, callback)
 
   --- @param completed vim.SystemCompleted
   local function on_exit(completed)
+    local j = 0
+    for i = 1, 1000000000 do
+      j = j + i
+    end
+    log.debug(string.format("j:%d", j))
     local result = CmdResult:new()
     if str.not_blank(completed.stdout) then
       result.stdout = str.split(str.trim(completed.stdout), "\n", { trimempty = true })

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -51,7 +51,7 @@ local function _run_cmd_async(args, cwd, callback)
 
   --- @param completed vim.SystemCompleted
   local function on_exit(completed)
-    local n = math.floor(math.random(1000000, 1000000000))
+    local n = 100000000
     local j = 0
     for i = 1, n do
       j = j + i

--- a/lua/gitlinker/util.lua
+++ b/lua/gitlinker/util.lua
@@ -47,13 +47,15 @@ end
 --- @return boolean
 local function is_timeout(start_at, timeout_ms)
   local now = now_milliseconds()
-  local yes = type(timeout_ms) == "number" and now_milliseconds() - start_at >= timeout_ms
+  local diff = type(timeout_ms) == "number" and (now - start_at) or -1
+  local yes = type(timeout_ms) == "number" and (now - start_at >= timeout_ms)
   log.debug(
     string.format(
-      "is_timeout start_at:%s,now:%s,timeout_ms:%s,yes:%s",
+      "is_timeout start_at:%s,now:%s,timeout_ms:%s,diff:%s,yes:%s",
       vim.inspect(start_at),
       vim.inspect(now),
       vim.inspect(timeout_ms),
+      vim.inspect(diff),
       vim.inspect(yes)
     )
   )


### PR DESCRIPTION
## Test Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Test Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Test Functions

- [ ] Use `GitLink(!)` to copy git link (or open in browser).
- [ ] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [ ] Copy git link with 'file' and 'rev' parameters.
