### PR TITLE
fix(configs): prevent plugin-level setup() from overriding user configuration

### DIFF
--- a/lua/gitlinker/configs.lua
+++ b/lua/gitlinker/configs.lua
@@ -277,6 +277,9 @@ end
 --- @param opts gitlinker.Options?
 --- @return gitlinker.Options
 M.setup = function(opts)
+  if Configs and Configs._routers and next(Configs._routers) then
+    return Configs
+  end
   local merged_routers = M._merge_routers(opts or {})
   Configs = vim.tbl_deep_extend("force", vim.deepcopy(Defaults), opts or {})
   Configs._routers = merged_routers


### PR DESCRIPTION
Fix #299 

The plugin automatically calls setup() in @plugin/gitlinker.lua without arguments. If users also call setup() with custom router configs in their Neovim config, the plugin-level call runs AFTER and overwrites the user's configuration.

Fix by adding early return in configs.setup() if Configs is already initialized.

## Test Platforms

- [ ] windows
- [x] macOS
- [ ] linux

## Test Hosts

- [x] Test on [github.com](https://github.com).
- [x] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Test Functions

- [x] Use `GitLink(!)` to copy git link (or open in browser).
- [x] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [x] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [x] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [x] Copy git link with 'file' and 'rev' parameters.
