### PR TITLE
fix(setup): detect whether plugin is loaded with global variable

### DIFF
--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -305,6 +305,7 @@ end
 
 --- @param opts gitlinker.Options?
 local function setup(opts)
+  vim.g.loaded_gitlinker = 1
   local confs = configs.setup(opts)
 
   -- logger

--- a/lua/gitlinker/configs.lua
+++ b/lua/gitlinker/configs.lua
@@ -277,9 +277,6 @@ end
 --- @param opts gitlinker.Options?
 --- @return gitlinker.Options
 M.setup = function(opts)
-  if Configs and Configs._routers and next(Configs._routers) then
-    return Configs
-  end
   local merged_routers = M._merge_routers(opts or {})
   Configs = vim.tbl_deep_extend("force", vim.deepcopy(Defaults), opts or {})
   Configs._routers = merged_routers

--- a/lua/gitlinker/configs.lua
+++ b/lua/gitlinker/configs.lua
@@ -277,6 +277,9 @@ end
 --- @param opts gitlinker.Options?
 --- @return gitlinker.Options
 M.setup = function(opts)
+  if Configs and Configs._routers and next(Configs._routers) then
+    return Configs
+  end
   local merged_routers = M._merge_routers(opts or {})
   Configs = vim.tbl_deep_extend("force", vim.deepcopy(Defaults), opts or {})
   Configs._routers = merged_routers

--- a/plugin/gitlinker.lua
+++ b/plugin/gitlinker.lua
@@ -1,1 +1,3 @@
-require("gitlinker").setup()
+if vim.fn.exists("g:loaded_gitlinker") == 0 then
+  require("gitlinker").setup()
+end


### PR DESCRIPTION
Close #299 , #300 

Adds a global variable `vim.g.loaded_gitlinker` to indicate whether this plugin is already initialized.

Hi @pirey, could you try this PR, see if it works for you?


## Test Platforms

- [ ] windows
- [ ] macOS
- [ ] linux

## Test Hosts

- [ ] Test on [github.com](https://github.com).
- [ ] Test on [gitlab.com](https://gitlab.com).
- [ ] Test on [bitbucket.org](https://bitbucket.org).
- [ ] Test on [codeberg.org](https://codeberg.org).
- [ ] Test on [git.samba.org](https://git.samba.org).

## Test Functions

- [ ] Use `GitLink(!)` to copy git link (or open in browser).
- [ ] Use `GitLink(!) blame` to copy the `/blame` link (or open in browser).
- [ ] Use `GitLink(!) default_branch` to open the `/main`/`/master` link in browser (or open in browser).
- [ ] Use `GitLink(!) current_branch` to open the current branch link in browser (or open in browser).
- [ ] Copy git link in a symlink directory of git repo.
- [ ] Copy git link in an un-pushed git branch, and receive an expected error.
- [ ] Copy git link in a pushed git branch but edited file, and receive a warning says the git link could be wrong.
- [ ] Copy git link with 'file' and 'rev' parameters.
